### PR TITLE
Adding htpasswd authentication to the openshift masters.

### DIFF
--- a/roles/openshift_on_openstack/templates/add_block.yml
+++ b/roles/openshift_on_openstack/templates/add_block.yml
@@ -19,9 +19,18 @@ openshift_clock_enabled: true
 # Enable cluster metrics
 use_cluster_metrics: true
 
-# Allow all authenthication.
-openshift_auth_type: allowall
-openshift_master_identity_providers: [{'name': 'allow_all', 'login': 'true', 'challenge': 'true', 'kind': 'AllowAllPasswordIdentityProvider'}]
+# Allow authentication using an Apache HTTP server authentication file.
+openshift_master_identity_providers:
+- name: 'htpasswd_auth'
+  login: 'true'
+  challenge: 'true'
+  kind: 'HTPasswdPasswordIdentityProvider'
+  filename: '/etc/origin/master/htpasswd'
+# Defining htpasswd users
+openshift_master_htpasswd_users:
+  - admin: 'admin'
+  - developer: 'developer'
+  - test: 'test'
 
 # Configure how often node iptables rules are refreshed.
 openshift_node_iptables_sync_period: 30s


### PR DESCRIPTION
Adding back in the htpasswd authentication to the OpenShift masters. I had this code in before, but the e2e tests failed and I used "allow all" authentication to pass certain tests. 

It does not appear that the variable "openshift_auth_type" is used any longer in the openshift-ansible repo.

Reference:
https://docs.openshift.com/enterprise/3.0/admin_guide/configuring_authentication.html#HTPasswdPasswordIdentityProvider