### PR TITLE
Add security group rules to allow uperf tests.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -26,3 +26,10 @@
   roles:
     - openshift_dns
     - openshift_on_openstack
+
+- name: OpenShift on OpenStack permissive security groups
+  hosts: openstack-server
+  vars_files:
+    - vars/openstack.yml
+  roles:
+    - openshift_on_openstack_secgroup

--- a/roles/openshift_on_openstack_secgroup/tasks/main.yml
+++ b/roles/openshift_on_openstack_secgroup/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+# Check for the existence of the OpenStack client.
+- name: Checking for the OpenStack client
+  stat:
+    path: "{{ openstack_location }}"
+  register: openstack_path
+
+# Fail when the openstack client path does not exist.
+- name: Aborting when the OpenStack client does not exist
+  fail:
+    msg: "The openstack client path '{{ openstack_location }}' is invalid."
+  when: openstack_path.stat.exists == false
+
+# The openstack variable includes the rc file and the path to the OpenStack client.
+- name: Setting openstack variable to source the rc file and contain path to client
+  set_fact:
+    openstack: "source {{ openstack_rc }}; {{ openstack_location }}"
+
+# Create the security group rule that allows uperf tests (TCP).  Ignore failures if a conflicting rule already exists.
+- name: Create the security group rule that allows uperf tests (TCP)
+  shell: "{{ openstack }} security group rule create --ingress --protocol tcp --dst-port {{ permissive_secgroup_ports }} {{ permissive_secgroup_name }}"
+  failed_when: False
+  when: permissive_secgroup_enable
+
+# Create the security group rule that allows uperf tests (UDP).  Ignore failures if a conflicting rule already exists.
+- name: Create the security group rule that allows uperf tests (UDP)
+  shell: "{{ openstack }} security group rule create --ingress --protocol udp --dst-port {{ permissive_secgroup_ports }} {{ permissive_secgroup_name }}"
+  failed_when: False
+  when: permissive_secgroup_enable

--- a/roles/openshift_on_openstack_secgroup/vars/main.yml
+++ b/roles/openshift_on_openstack_secgroup/vars/main.yml
@@ -1,0 +1,9 @@
+---
+# The path to the OpenStack RC file on the openstack-server, may be named differently than other servers.
+openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/overcloudrc', true) }}"
+# Allow permissive security group rules by calling openshift_on_openstack_secgroup role.
+permissive_secgroup_enable: "{{ openstack_permissive_secgroup_enable|default('true', true) }}"
+# Permissive common security group rules inbound TCP/UDP port range.
+permissive_secgroup_ports: "{{ openstack_permissive_secgroup_ports|default('1024:65535', true) }}"
+# OpenStack security group name to add permissive security group rules to.
+permissive_secgroup_name: "{{ openstack_permissive_secgroup_name|default('openshift-ansible-scale-ci.example.com-common-secgrp', true) }}"

--- a/vars/openstack.yml
+++ b/vars/openstack.yml
@@ -25,3 +25,9 @@ openstack_server_name: "{{ lookup('env', 'server_name')|default('ansible-host', 
 openstack_subnet_name: "{{ lookup('env', 'subnet_name')|default('ci_subnet', true) }}"
 # The subnet range to use on the OpenStack private subnet (\23 == 510 addresses).
 openstack_subnet_range: "{{ lookup('env', 'subnet_range')|default('192.168.4.0/23', true) }}"
+# Allow permissive security group rules by calling openshift_on_openstack_secgroup role.
+openstack_permissive_secgroup_enable: "{{ lookup('env', 'permissive_secgroup_enable')|default('true', true) }}"
+# Permissive common security group rules inbound TCP/UDP port range.
+openstack_permissive_secgroup_ports: "{{ lookup('env', 'permissive_secgroup_ports')|default('1024:65535', true) }}"
+# OpenStack security group name to add permissive security group rules to.
+openstack_permissive_secgroup_name: "{{ lookup('env', 'permissive_secgroup_name')|default('openshift-ansible-scale-ci.example.com-common-secgrp', true) }}"


### PR DESCRIPTION
This is a temporary role that allows the uperf test client to work. Once openshift-ansible supports adding custom TCP/UDP inbound rules, this role should be deleted and replaced by that functionality.