### PR TITLE
Specify Prometheus image version explicitly.

### DIFF
--- a/roles/openshift_on_openstack/templates/add_block.yml
+++ b/roles/openshift_on_openstack/templates/add_block.yml
@@ -45,6 +45,13 @@ openshift_storage_glusterfs_storageclass_default: true
 openshift_hosted_prometheus_deploy: true
 openshift_prometheus_state: present
 openshift_prometheus_image_prefix: registry.reg-aws.openshift.com:443/openshift3/
+openshift_prometheus_image_version: 'v3.9'
+openshift_prometheus_proxy_image_prefix: "{{ openshift_prometheus_image_prefix }}"
+openshift_prometheus_proxy_image_version: "{{ openshift_prometheus_image_version }}"
+openshift_prometheus_alertmanager_image_prefix: "{{ openshift_prometheus_image_prefix }}"
+openshift_prometheus_alertmanager_image_version: "{{ openshift_prometheus_image_version }}"
+openshift_prometheus_alertbuffer_image_prefix: "{{ openshift_prometheus_image_prefix }}"
+openshift_prometheus_alertbuffer_image_version: "{{ openshift_prometheus_image_version }}"
 openshift_prometheus_storage_type: pvc
 openshift_prometheus_storage_volume_size: 40Gi
 openshift_prometheus_alertmanager_storage_type: pvc


### PR DESCRIPTION
Unless the image versions are specified explicitly, "openshift_image_tag" versions are pulled by default.