### PR TITLE
Enable ansible logging.

### DIFF
--- a/roles/openshift_on_openstack/tasks/main.yml
+++ b/roles/openshift_on_openstack/tasks/main.yml
@@ -100,6 +100,14 @@
     dest: /etc/ansible/ansible.cfg
   become: true
 
+# Enable ansible logging.
+- name: Enabling ansible logging
+  replace:
+    dest: /etc/ansible/ansible.cfg
+    regexp: '^#?log_path\s*=.*'
+    replace: 'log_path = /var/tmp/ansible.log'
+  become: true
+
 # Check if the nsupdate_file exists.
 - name: Checking file system status for the nsupdate file
   stat:


### PR DESCRIPTION
https://github.com/openshift/openshift-ansible/pull/7141 is not going in, therefore we'll have to live with ansible.cfg being slightly different than in openshift-ansible.

I've decided to put the log file to "/var/tmp/ansible.log", as "/tmp" is too temporary, and "/var/log" needs admin permissions and we run first as cloud-user and only then potentially as "root" (when running certain tasks manually).  This shouldn't cause any problems in our environment, unless I've missed something, of course.
