### PR TITLE
Fixes for dns and spelling/typo

### DIFF
--- a/roles/openshift_dns/vars/main.yml
+++ b/roles/openshift_dns/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # The algorithm to use when creating the DNS update key.
-dns_key_algorithm: "{{ lookup('env', 'dns_key_algorithm')|default('hmac-sha256', true) }}"
+dns_key_algorithm: "{{ lookup('env', 'dns_key_algorithm')|default('hmac-md5', true) }}"
 # The DNS update key file name.
 dns_key_file: "{{ lookup('env', 'dns_update_file')|default('dns_update.key', true) }}"
 # The key name when creating the DNS update key.

--- a/roles/openshift_on_openstack/tasks/main.yml
+++ b/roles/openshift_on_openstack/tasks/main.yml
@@ -174,7 +174,7 @@
   with_items: "{{ debug_information['results'] }}"
 
 # Set the path for the prerequisite log file.
-- name: Creating a variable for the prerequsite log file
+- name: Creating a variable for the prerequisite log file
   set_fact:
     prerequisite_log: "{{ ansible_user_dir }}/openshift_prerequisites.log"
 


### PR DESCRIPTION
Changes from the openshift-ansible-contrib repo made the dns algorithm go back to md5, so the automation needs to default to md5 again.

Found a spelling error in the openshift_on_openstack role name.