### PR TITLE
Allow rcpbind for CNS block in cns-secgrp.

### DIFF
--- a/roles/openshift_on_openstack_secgroup/tasks/main.yml
+++ b/roles/openshift_on_openstack_secgroup/tasks/main.yml
@@ -27,3 +27,9 @@
   shell: "{{ openstack }} security group rule create --ingress --protocol udp --dst-port {{ permissive_secgroup_ports }} {{ permissive_secgroup_name }}"
   failed_when: False
   when: permissive_secgroup_enable
+
+# Create the security group rule that allows RPC bind for CNS block.
+- name: Create the security group rule that allows RPC bind for CNS block.
+  shell: "{{ openstack }} security group rule create --ingress --protocol tcp --dst-port 111 {{ cns_secgroup_name }}"
+  failed_when: False
+  when: permissive_secgroup_enable

--- a/roles/openshift_on_openstack_secgroup/vars/main.yml
+++ b/roles/openshift_on_openstack_secgroup/vars/main.yml
@@ -7,3 +7,5 @@ permissive_secgroup_enable: "{{ openstack_permissive_secgroup_enable|default('tr
 permissive_secgroup_ports: "{{ openstack_permissive_secgroup_ports|default('1024:65535', true) }}"
 # OpenStack security group name to add permissive security group rules to.
 permissive_secgroup_name: "{{ openstack_permissive_secgroup_name|default('openshift-ansible-scale-ci.example.com-common-secgrp', true) }}"
+# OpenStack security group name to add cns security group rules to.
+cns_secgroup_name: "{{ openstack_cns_secgroup_name|default('openshift-ansible-scale-ci.example.com-cns-secgrp', true) }}"


### PR DESCRIPTION
The security policy blocks RPC bind between CNS nodes. This change
allows 111/TCP ingress rule in cns-secgrp policy.  This is a temporary
fix before https://github.com/openshift/openshift-ansible/pull/7371
merges.

@ekuric, ptal