### PR TITLE
Create the security group rule that allows HTTP.

### DIFF
--- a/roles/openstack_create_server/tasks/main.yml
+++ b/roles/openstack_create_server/tasks/main.yml
@@ -105,12 +105,16 @@
 - name: Creating the security group rule that allows ssh
   shell: "{{ openstack }} security group rule create --ingress --protocol tcp --dst-port 22 {{ security_group_uuid['stdout'] }} --format value -c id"
 
+# Create the security group rule that allows HTTP (TCP port 80-81).
+- name: Creating the security group rule for http
+  shell: "{{ openstack }} security group rule create --ingress --protocol tcp --dst-port 80:81 {{ security_group_uuid['stdout'] }} --format value -c id"
+
 # Create the security group rule that allows secure HTTP (TCP port 443).
-- name: Creating the security group for secure http
+- name: Creating the security group rule for secure http
   shell: "{{ openstack }} security group rule create --ingress --protocol tcp --dst-port 443 {{ security_group_uuid['stdout'] }} --format value -c id"
 
 # Create the security group rule that allows connections to cluster loader synchronization endpoint (TCP port 9090).
-- name: Creating the security group for secure http
+- name: Creating the security group rule for cluster loader synchronization endpoint
   shell: "{{ openstack }} security group rule create --ingress --protocol tcp --dst-port 9090 {{ security_group_uuid['stdout'] }} --format value -c id"
 
 # Create the floating ip address on the public network.


### PR DESCRIPTION
This PR fixes a few typos and add security group rule that also allows HTTP on port 80 and 81.  The rationale for this is to run a simple web server on ansible-host to view pbench results as the tests run before they're copied onto a pbench server.
