### PR TITLE
Changing shade version to 1.27.1.

### DIFF
--- a/roles/openshift_dependencies/vars/main.yml
+++ b/roles/openshift_dependencies/vars/main.yml
@@ -29,7 +29,7 @@ packages:
     - jmespath==0.9.3
     - python-openstackclient==3.14.0
     - python-heatclient==1.14.0
-    - shade==1.26.0
+    - shade==1.27.1
 pip: pip
 # When the virtualenv_directory is defined, a Python virtual environment is created.
 # virtualenv_directory: virtualenv


### PR DESCRIPTION
Shade 1.27.1 is out, fixing public/private IP issues in 1.27.0 and containing the stack scalability patch. @mbruzek, we need this in before the next scaleup.