### PR TITLE
Updating quota fore more compute/RAM and changing minimum flavor sizes.

### DIFF
--- a/roles/openstack_create_server/vars/main.yml
+++ b/roles/openstack_create_server/vars/main.yml
@@ -2,7 +2,7 @@
 # Rough equivalents of the Amazon ec2 flavors.
 ec2_flavors:
   # https://aws.amazon.com/ec2/previous-generation/
-  - { name: m1.small, vcpu: 1, memory: 1740, disk: 64 }
+  - { name: m1.small, vcpu: 1, memory: 1740, disk: 71 }
   - { name: m1.medium, vcpu: 1, memory: 3840, disk: 96 }
   - { name: m1.large, vcpu: 2, memory: 7680, disk: 128 }
   # https://aws.amazon.com/ec2/instance-types/#m4
@@ -12,8 +12,8 @@ ec2_flavors:
   - { name: m4.4xlarge, vcpu: 16, memory: 65536, disk: 400 }
   - { name: m4.10xlarge, vcpu: 40, memory: 163840, disk: 500 }
   # https://aws.amazon.com/ec2/instance-types/#r4
-  - { name: r4.large, vcpu: 2, memory: 15616, disk: 64 }
-  - { name: r4.xlarge, vcpu: 4, memory: 31232, disk: 64 }
+  - { name: r4.large, vcpu: 2, memory: 15616, disk: 71 }
+  - { name: r4.xlarge, vcpu: 4, memory: 31232, disk: 71 }
   - { name: r4.2xlarge, vcpu: 8, memory: 62464, disk: 96 }
   - { name: r4.4xlarge, vcpu: 16, memory: 124928, disk: 128 }
   - { name: r4.8xlarge, vcpu: 32, memory: 249856, disk: 256 }
@@ -24,7 +24,7 @@ openshift_flavors:
   - { name: load_balancer, vcpu: 4, memory: 16384, disk: 128 }
   - { name: infra_elastic, vcpu: 40, memory: 163840, disk: 128, property: '--property "pci_passthrough:alias"="nvme:1"' }
   - { name: master_etcd, vcpu: 16, memory: 124928, disk: 256, property: '--property "pci_passthrough:alias"="nvme:1"' }
-  - { name: node_small, vcpu: 1, memory: 2048, disk: 64 }
+  - { name: node_small, vcpu: 1, memory: 2048, disk: 71 }
   - { name: node_medium, vcpu: 4, memory: 16384, disk: 96 }
   - { name: node_large, vcpu: 8, memory: 32768, disk: 128 }
 # The path to the OpenStack RC file on the openstack-server, may be named differently than other servers.
@@ -35,18 +35,18 @@ remote_private_key_path: "{{ lookup('env', 'remote_private_key_path')|default(in
 remote_public_key_path: "{{ lookup('env', 'remote_public_key_path')|default(install_directory ~ '/key.public', true) }}"
 # The quota structure to set for this OpenStack installation.
 quotas:
-  cores: 2304
+  cores: 2432
   gigabytes: 50000
   instances: 550
   ports: 10000
-  ram: 9437184
+  ram: 9961472
   secgroups: 25
   volumes: 50000
   floating-ips: 512
 # Rough equivalents of the Google cloud instance sizes.
 standard_flavors:
   # https://cloud.google.com/compute/docs/machine-types
-  - { name: n1-standard-1, vcpu: 1, memory: 3750, disk: 60 }
+  - { name: n1-standard-1, vcpu: 1, memory: 3750, disk: 71 }
   - { name: n1-standard-2, vcpu: 2, memory: 7500, disk: 80 }
   - { name: n1-standard-4, vcpu: 4, memory: 15000, disk: 80 }
   - { name: n1-standard-8, vcpu: 8, memory: 30000, disk: 100 }


### PR DESCRIPTION
Updates to the image size resulted in images of 66GiB and we got 2 more compute nodes so updating the cpu and ram quotas.