### PR TITLE
Moving OCP on OSP permissive security groups in front of OCP install.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -18,6 +18,13 @@
   roles:
     - openshift_dependencies
 
+- name: OpenShift on OpenStack permissive security groups
+  hosts: openstack-server
+  vars_files:
+    - vars/openstack.yml
+  roles:
+    - openshift_on_openstack_secgroup
+
 - name: Install OpenShift on OpenStack
   hosts: target-server
   vars_files:
@@ -26,10 +33,3 @@
   roles:
     - openshift_dns
     - openshift_on_openstack
-
-- name: OpenShift on OpenStack permissive security groups
-  hosts: openstack-server
-  vars_files:
-    - vars/openstack.yml
-  roles:
-    - openshift_on_openstack_secgroup


### PR DESCRIPTION
1) TCP 111 inbound is needed for GlusterFS block, which is required during OpenShift install.
2) When OpenShift install fails, permissive groups rules are never set, failing a manual OpenShift install.