### PR TITLE
Revert "Moving OCP on OSP permissive security groups in front of OCP install."

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -18,13 +18,6 @@
   roles:
     - openshift_dependencies
 
-- name: OpenShift on OpenStack permissive security groups
-  hosts: openstack-server
-  vars_files:
-    - vars/openstack.yml
-  roles:
-    - openshift_on_openstack_secgroup
-
 - name: Install OpenShift on OpenStack
   hosts: target-server
   vars_files:
@@ -33,3 +26,10 @@
   roles:
     - openshift_dns
     - openshift_on_openstack
+
+- name: OpenShift on OpenStack permissive security groups
+  hosts: openstack-server
+  vars_files:
+    - vars/openstack.yml
+  roles:
+    - openshift_on_openstack_secgroup


### PR DESCRIPTION
Reverts redhat-performance/scale-ci-ansible#34

@jmencak and I had a conversation about this pull request. The code only adds to a security group that it assumes is already created. I don't think the security group is created at this point. It looks to be part of the heat stack creation: https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_openstack/templates/heat_stack.yaml.j2#L280

I think we could move this call to after the provision but before the OpenStack install command (which fails on occasion).