### PR TITLE
openshift-ansible patch for CNS block heat template.

### DIFF
--- a/roles/openshift_ansible_patch/files/20-rcpbind_for_CNS.patch
+++ b/roles/openshift_ansible_patch/files/20-rcpbind_for_CNS.patch
@@ -1,0 +1,14 @@
+--- openshift-ansible.orig/roles/openshift_openstack/templates/heat_stack.yaml.j2
++++ openshift-ansible/roles/openshift_openstack/templates/heat_stack.yaml.j2
+@@ -598,6 +598,11 @@ resources:
+           params:
+             cluster_id: {{ openshift_openstack_stack_name }}
+       rules:
++        # Allow rcpbind for CNS block
++        - direction: ingress
++          protocol: tcp
++          port_range_min: 111
++          port_range_max: 111
+         # glusterfs_sshd
+         - direction: ingress
+           protocol: tcp


### PR DESCRIPTION
This has merged for 3.10, but not for 3.9.