### PR TITLE
Removing TCP 111 for CNS, handled elsewhere.

### DIFF
--- a/roles/openshift_on_openstack_secgroup/tasks/main.yml
+++ b/roles/openshift_on_openstack_secgroup/tasks/main.yml
@@ -27,9 +27,3 @@
   shell: "{{ openstack }} security group rule create --ingress --protocol udp --dst-port {{ permissive_secgroup_ports }} {{ permissive_secgroup_name }}"
   failed_when: False
   when: permissive_secgroup_enable
-
-# Create the security group rule that allows RPC bind for CNS block.
-- name: Create the security group rule that allows RPC bind for CNS block.
-  shell: "{{ openstack }} security group rule create --ingress --protocol tcp --dst-port 111 {{ cns_secgroup_name }}"
-  failed_when: False
-  when: permissive_secgroup_enable

--- a/roles/openshift_on_openstack_secgroup/vars/main.yml
+++ b/roles/openshift_on_openstack_secgroup/vars/main.yml
@@ -7,5 +7,3 @@ permissive_secgroup_enable: "{{ openstack_permissive_secgroup_enable|default('tr
 permissive_secgroup_ports: "{{ openstack_permissive_secgroup_ports|default('1024:65535', true) }}"
 # OpenStack security group name to add permissive security group rules to.
 permissive_secgroup_name: "{{ openstack_permissive_secgroup_name|default('openshift-ansible-' ~ clusterid ~ '.' ~ dns_domain ~ '-common-secgrp', true) }}"
-# OpenStack security group name to add cns security group rules to.
-cns_secgroup_name: "{{ openstack_cns_secgroup_name|default('openshift-ansible-' ~ clusterid ~ '.' ~ dns_domain ~ '-cns-secgrp', true) }}"


### PR DESCRIPTION
Removing TCP 111 for CNS.  This was a hack in the first place for this role and is now handled in  openshift_ansible_patch role for 3.9 and upstream patch already merged for 3.10.