### PR TITLE
Reverting role called in playbook, adding role included from other role.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -25,7 +25,6 @@
     - vars/openshift.yml
   roles:
     - openshift_dns
-    - openshift_ansible_patch
     - openshift_on_openstack
 
 - name: OpenShift on OpenStack permissive security groups

--- a/roles/openshift_on_openstack/tasks/main.yml
+++ b/roles/openshift_on_openstack/tasks/main.yml
@@ -62,6 +62,11 @@
     version: "{{ openshift_ansible_version }}"
   when: openshift_ansible['stat']['exists'] == false
 
+# Include the tasks from the openshift_ansible_patch role.
+- name: Include the tasks to patch files in the openshift-ansible directory
+  include_role:
+    name: openshift_ansible_patch
+
 # Get the DNS server addresses from OpenStack.
 - name: Getting the IP address for the DNS VM ns-master
   shell: "{{ openstack }} server show ns-master.{{ clusterid}}.{{ dns_domain }} --format value -c addresses"


### PR DESCRIPTION
The openshift-ansible directory did not yet exist at the time when this role was called and the role failed the deploy automation.

I did some experimentation and found that including the tasks from another role was what we wanted.