### PR TITLE
Adding the new_nodes group to OSEv3:children

### DIFF
--- a/roles/openshift_on_openstack_scaleup/tasks/main.yml
+++ b/roles/openshift_on_openstack_scaleup/tasks/main.yml
@@ -91,7 +91,7 @@
 # Write the group name for the new nodes inventory file.
 - name: Writing the group header for the new nodes inventory file
   copy:
-    content: "[new_nodes]\n"
+    content: "[OSEv3:children]\nnew_nodes\n[new_nodes]\n"
     dest: "{{ new_nodes_inventory }}"
 
 # Create the new inventory file


### PR DESCRIPTION
A discussion on IRC in #openshift-ansible leads me to believe the reason we are not getting the OSEv3 variables is because the new nodes are not children of the OSEv3 group.

This will test the theory.