### PR TITLE
Add support for faster OpenShift scale-up times.

### DIFF
--- a/roles/openshift_ansible_patch/files/30-inventory-no-app-nodes.patch
+++ b/roles/openshift_ansible_patch/files/30-inventory-no-app-nodes.patch
@@ -1,0 +1,23 @@
+--- openshift-ansible.orig/playbooks/openstack/inventory.py	2018-03-15 16:09:05.963878499 +0100
++++ openshift-ansible/playbooks/openstack/inventory.py	2018-03-15 16:11:56.902622891 +0100
+@@ -11,6 +11,7 @@
+ 
+ from collections import Mapping
+ import json
++import os
+ 
+ import shade
+ 
+@@ -38,7 +39,11 @@
+     cns = [server.name for server in cluster_hosts
+            if server.metadata['host-type'] == 'cns']
+ 
+-    nodes = list(set(masters + infra_hosts + app + cns))
++    no_app_nodes = os.environ.get('INV_NO_APP_NODES', 'false').lower() == "true"
++    if no_app_nodes:
++        nodes = list(set(masters + infra_hosts + cns))
++    else:
++        nodes = list(set(masters + infra_hosts + app + cns))
+ 
+     dns = [server.name for server in cluster_hosts
+            if server.metadata['host-type'] == 'dns']

--- a/roles/openshift_on_openstack_scaleup/tasks/main.yml
+++ b/roles/openshift_on_openstack_scaleup/tasks/main.yml
@@ -4,6 +4,11 @@
   set_fact:
     ansible_playbook: ". {{ openstack_rc }}; ansible-playbook"
 
+# Create a variable that sources the rc file, sets INV_NO_APP_NODES=true and runs the ansible-playbook command.
+- name: Creating a variable that sources the OpenStack rc file, sets INV_NO_APP_NODES=true and runs the ansible-playbook command
+  set_fact:
+    ansible_playbook_scaleup: ". {{ openstack_rc }}; INV_NO_APP_NODES=true ansible-playbook"
+
 # Create a variable that sources the rc file and runs the OpenStack client command.
 - name: Creating a variable that sources the OpenStack rc file and runs the openstack client command
   set_fact:
@@ -115,7 +120,7 @@
 # Scale up the OpenShift cluster.
 - name: Scaling up the OpenShift resources
   shell: >
-    {{ ansible_playbook }} -vvv
+    {{ ansible_playbook_scaleup }} -vvv
     --user openshift
     -i inventory/
     -i {{ inventory_py }}


### PR DESCRIPTION
This PR adds support for not outputting application nodes by inventory.py when INV_NO_APP_NODES environment variable is set.  This is useful during OpenShift scaleups -- makes scaleup times faster.