### PR TITLE
The version of Ansible has changed in 3.9 to 2.4.3

### DIFF
--- a/roles/openshift_dependencies/vars/main.yml
+++ b/roles/openshift_dependencies/vars/main.yml
@@ -23,7 +23,7 @@ packages:
     - python-devel
     - python-virtualenv
   python:
-    - ansible==2.4.2
+    - ansible==2.4.3
     - dnspython==1.15.0
     - Jinja2==2.10
     - jmespath==0.9.3


### PR DESCRIPTION
While running the installer today I encountered a new error:

FATAL: Current Ansible version (2.4.2.0) is not supported. Supported versions: 2.4.3.0 or newer

It seems OpenShift requires a new version of Ansible.