### PR TITLE
An additional port 24010 (glusterblockd) is needed for CNS block.

### DIFF
--- a/roles/openshift_ansible_patch/files/40-iscsi-targets-glusterblockd.patch
+++ b/roles/openshift_ansible_patch/files/40-iscsi-targets-glusterblockd.patch
@@ -1,14 +1,26 @@
 --- openshift-ansible.orig/roles/openshift_openstack/templates/heat_stack.yaml.j2
 +++ openshift-ansible/roles/openshift_openstack/templates/heat_stack.yaml.j2
-@@ -435,6 +435,11 @@
+@@ -387,6 +387,11 @@
            protocol: tcp
            port_range_min: 2222
            port_range_max: 2222
-+        # CNS block requires access to iSCSI 3260
++        # iscsi-targets
 +        - direction: ingress
 +          protocol: tcp
 +          port_range_min: 3260
 +          port_range_max: 3260
          # heketi dialing backends
+         - direction: ingress
+           protocol: tcp
+@@ -402,6 +407,11 @@
+           protocol: tcp
+           port_range_min: 24008
+           port_range_max: 24008
++        # glusterblockd
++        - direction: ingress
++          protocol: tcp
++          port_range_min: 24010
++          port_range_max: 24010
+         # glusterfs_bricks
          - direction: ingress
            protocol: tcp


### PR DESCRIPTION
Based on https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_storage_glusterfs/defaults/main.yml#L101