### PR TITLE
Getting flavors from environment variables to increase flexibility.

### DIFF
--- a/roles/openshift_on_openstack/vars/main.yml
+++ b/roles/openshift_on_openstack/vars/main.yml
@@ -13,9 +13,9 @@ all_yml:
   - { find: "^#?openshift_openstack_master_flavor:.*", replace: "openshift_openstack_master_flavor: \"master_etcd\"" }
   - { find: "^#?openshift_openstack_infra_flavor:.*", replace: "openshift_openstack_infra_flavor: \"infra_elastic\"" }
   - { find: "^#?openshift_openstack_cns_flavor:.*", replace: "openshift_openstack_cns_flavor: \"container_storage\"" }
-  - { find: "^#?openshift_openstack_node_flavor.*", replace: "openshift_openstack_node_flavor: \"node_medium\"" }
+  - { find: "^#?openshift_openstack_node_flavor.*", replace: "openshift_openstack_node_flavor: \"{{ openshift_node_flavor }}\"" }
   - { find: "^#?openshift_openstack_lb_flavor:.*", replace: "openshift_openstack_lb_flavor: \"load_balancer\"" }
-  - { find: "^#?openshift_openstack_default_flavor:.*", replace: "openshift_openstack_default_flavor: \"m1.medium\"" }
+  - { find: "^#?openshift_openstack_default_flavor:.*", replace: "openshift_openstack_default_flavor: \"{{ openshift_default_flavor }}\"" }
   - { find: "^#?openshift_openstack_subnet_cidr:.*", replace: "openshift_openstack_subnet_cidr: \"192.168.96.0/20\""}
   - { find: "^#?openshift_openstack_pool_start:.*", replace: "openshift_openstack_pool_start: \"192.168.96.3\""}
   - { find: "^#?openshift_openstack_pool_end:.*", replace: "openshift_openstack_pool_end: \"192.168.111.254\""}

--- a/vars/openshift.yml
+++ b/vars/openshift.yml
@@ -7,3 +7,7 @@ openshift_ansible_version: "{{ lookup('env', 'openshift_ansible_version')|defaul
 openshift_ansible_contrib_repo: "{{ lookup('env', 'openshift_ansible_contrib_repo')|default('https://github.com/openshift/openshift-ansible-contrib', true) }}"
 # This version can be a branch, tag, or hash for testing pull requests.
 openshift_ansible_contrib_version: "{{ lookup('env', 'openshift_ansible_contrib_version')|default('master', true) }}"
+# The flavor to use as default for other OpenShift VMs.
+openshift_default_flavor: "{{ lookup('env', 'openshift_default_flavor')|default('m1.medium', true) }}"
+# The flavor to use for the OpenShift nodes.
+openshift_node_flavor: "{{ lookup('env', 'openshift_node_flavor')|default('node_large', true) }}"


### PR DESCRIPTION
This change will allow us to specify a flavor name for the OpenShift node VMs as an environment variable.