### PR TITLE
Increasing instances to match floating ip quota.

### DIFF
--- a/roles/openstack_create_server/vars/main.yml
+++ b/roles/openstack_create_server/vars/main.yml
@@ -37,7 +37,7 @@ remote_public_key_path: "{{ lookup('env', 'remote_public_key_path')|default(inst
 quotas:
   cores: 2432         # Number of instance cores (VCPUs) allowed per project.
   gigabytes: 100000   # Volume gigabytes allowed for each project.
-  instances: 2001     # Number of instances (VMs) allowed per project.
+  instances: 2046     # Number of instances (VMs) allowed per project.
   ports: 10000
   ram: 9961472        # Megabytes of instance ram allowed per project.
   secgroups: 25


### PR DESCRIPTION
A limit of 2001 would only allow us to have 1989 OpenShift app nodes because 12 VMs are used for infrastructure (masters, infras, cns, lb, dns, jump host). I am quite sure we want to get to a round number of 2K when the cluster is ready to go that high (not right now).