### PR TITLE
Allowing root to login and chaning quotas to 4096.

### DIFF
--- a/roles/openshift_dependencies/tasks/main.yml
+++ b/roles/openshift_dependencies/tasks/main.yml
@@ -79,12 +79,30 @@
     dest: "{{ ansible_user_dir }}/.ssh/id_rsa.pub"
     mode: 0644
 
-# Increase the sshd MaxSessions.
-- name: Increasing the sshd maximum sessions
+# Add the public key to the root user's authorized_keys file.
+- name: Copying the public key to the root user's authorized_keys
+  copy:
+    src: "{{ ansible_public_key_file }}"
+    dest: /root/.ssh/authorized_keys
+    mode: 0600
+  become: true
+
+# Change the sshd configuration.
+- name: Change the sshd configuration
   lineinfile:
     path: /etc/ssh/sshd_config
-    regexp: "^#MaxSessions"
-    line: "MaxSessions 100"
+    regexp: "{{ item['search'] }}"
+    line: "{{ item['replace'] }}"
+  with_items:
+    - { search: "^#?MaxSessions.*", replace: "MaxSessions 100" }
+    - { search: "^#?PermitRootLogin.*", replace: "PermitRootLogin yes"}
+  become: true
+
+# Restart the sshd service to enable the changes.
+- name: Restarting the sshd service
+  service:
+    name: sshd
+    state: restarted
   become: true
 
 # Copy the OpenStack rc file from the Ansible host to the target host.

--- a/roles/openstack_create_server/vars/main.yml
+++ b/roles/openstack_create_server/vars/main.yml
@@ -37,12 +37,12 @@ remote_public_key_path: "{{ lookup('env', 'remote_public_key_path')|default(inst
 quotas:
   cores: 2432         # Number of instance cores (VCPUs) allowed per project.
   gigabytes: 100000   # Volume gigabytes allowed for each project.
-  instances: 2046     # Number of instances (VMs) allowed per project.
+  instances: 4096     # Number of instances (VMs) allowed per project.
   ports: 10000
   ram: 9961472        # Megabytes of instance ram allowed per project.
   secgroups: 25
   volumes: 50000      # Volumes allowed for each project.
-  floating-ips: 2046  # Number of floating IP addresses allowed per project.
+  floating-ips: 4096  # Number of floating IP addresses allowed per project.
 # Rough equivalents of the Google cloud instance sizes.
 standard_flavors:
   # https://cloud.google.com/compute/docs/machine-types


### PR DESCRIPTION
Allowing root involves:
1. writing the public key to authorized_keys
2. updating the sshd_config
3. restarting the sshd service

Also updated the quota for floating ips and instances to 4096 which is a limit we hit while scale testing.