### PR TITLE
Use the ansible_user key from the remote host listing.

### DIFF
--- a/roles/image_preparation/vars/main.yml
+++ b/roles/image_preparation/vars/main.yml
@@ -6,7 +6,7 @@ image_directory: image_builder/qcow_images
 # Copy the images to this remote host.
 remote_host: "{{ groups['openstack-server'][0] }}"
 # The remote host user.
-user_remote: "{{ hostvars[remote_host] }}"
+user_remote: "{{ hostvars[remote_host]['ansible_user'] }}"
 # Copy the images to this directory on the remote host.
 remote_image_directory: "/home/{{ user_remote }}/{{ clusterid }}"
 # A string path relative to the user's home directory to the rhel image.


### PR DESCRIPTION
Bug fix. The code is returning a host dictionary not the user we are looking for.