### PR TITLE
The SVT_Conformance job uses "MASTER_HOSTNAME" as the property key.

### DIFF
--- a/roles/openshift_on_openstack/tasks/main.yml
+++ b/roles/openshift_on_openstack/tasks/main.yml
@@ -281,9 +281,9 @@
   command: "scp openshift@{{ master_address }}:.kube/config {{ ansible_user_dir }}/.kube/config"
 
 # Add the master host address to the properties file.
-- name: Adding the MASTER_HOST to the properties file
+- name: Adding the MASTER_HOSTNAME to the properties file
   lineinfile:
-    line: "MASTER_HOST={{ master_address }}"
+    line: "MASTER_HOSTNAME={{ master_address }}"
     path: "{{ properties_file }}"
   delegate_to: localhost
 


### PR DESCRIPTION
The following job did not succeed because it was looking for MASTER_HOSTNAME and this job gave it MASTER_HOST.