### PR TITLE
Further optimizations to inventory.py.

### DIFF
--- a/roles/openshift_ansible_patch/files/30-inventory-no-app-nodes.patch
+++ b/roles/openshift_ansible_patch/files/30-inventory-no-app-nodes.patch
@@ -1,5 +1,5 @@
---- openshift-ansible.orig/playbooks/openstack/inventory.py	2018-03-15 16:09:05.963878499 +0100
-+++ openshift-ansible/playbooks/openstack/inventory.py	2018-03-15 16:11:56.902622891 +0100
+--- openshift-ansible.orig/playbooks/openstack/inventory.py
++++ openshift-ansible/playbooks/openstack/inventory.py
 @@ -11,6 +11,7 @@
  
  from collections import Mapping
@@ -8,16 +8,17 @@
  
  import shade
  
-@@ -38,7 +39,11 @@
-     cns = [server.name for server in cluster_hosts
-            if server.metadata['host-type'] == 'cns']
+@@ -81,9 +82,12 @@
  
--    nodes = list(set(masters + infra_hosts + app + cns))
+     # TODO(shadower): filter the servers based on the `OPENSHIFT_CLUSTER`
+     # environment variable.
 +    no_app_nodes = os.environ.get('INV_NO_APP_NODES', 'false').lower() == "true"
-+    if no_app_nodes:
-+        nodes = list(set(masters + infra_hosts + cns))
-+    else:
-+        nodes = list(set(masters + infra_hosts + app + cns))
++
+     cluster_hosts = [
+         server for server in cloud.list_servers()
+-        if 'metadata' in server and 'clusterid' in server.metadata]
++        if 'metadata' in server and 'clusterid' in server.metadata and
++            (not no_app_nodes or server.metadata['sub-host-type'] != 'app')]
  
-     dns = [server.name for server in cluster_hosts
-            if server.metadata['host-type'] == 'dns']
+     inventory = base_openshift_inventory(cluster_hosts)
+ 


### PR DESCRIPTION
Do not return app-nodes in any groups during scaleups.

See: https://github.com/openshift/openshift-ansible/pull/7581