### PR TITLE
Cleaning up ill formatted text in the automation output

### DIFF
--- a/roles/openshift_on_openstack_secgroup/tasks/main.yml
+++ b/roles/openshift_on_openstack_secgroup/tasks/main.yml
@@ -16,14 +16,16 @@
   set_fact:
     openstack: "source {{ openstack_rc }}; {{ openstack_location }}"
 
-# Create the security group rule that allows uperf tests (TCP).  Ignore failures if a conflicting rule already exists.
+# Create the security group rule that allows uperf tests (TCP).
 - name: Create the security group rule that allows uperf tests (TCP)
-  shell: "{{ openstack }} security group rule create --ingress --protocol tcp --dst-port {{ permissive_secgroup_ports }} {{ permissive_secgroup_name }}"
-  failed_when: False
+  shell: "{{ openstack }} security group rule create --ingress --protocol tcp --dst-port {{ permissive_secgroup_ports }} {{ permissive_secgroup_name }} --format value -c id"
+  # Ignore failures if a conflicting rule already exists.
+  ignore_errors: yes
   when: permissive_secgroup_enable
 
-# Create the security group rule that allows uperf tests (UDP).  Ignore failures if a conflicting rule already exists.
+# Create the security group rule that allows uperf tests (UDP).
 - name: Create the security group rule that allows uperf tests (UDP)
-  shell: "{{ openstack }} security group rule create --ingress --protocol udp --dst-port {{ permissive_secgroup_ports }} {{ permissive_secgroup_name }}"
-  failed_when: False
+  shell: "{{ openstack }} security group rule create --ingress --protocol udp --dst-port {{ permissive_secgroup_ports }} {{ permissive_secgroup_name }} --format value -c id"
+  # Ignore failures if a conflicting rule already exists.
+  ignore_errors: yes
   when: permissive_secgroup_enable


### PR DESCRIPTION
The last run of the automation was successful but the last 2 tasks had openstack tables printed out that I was not able to read. Cleaning that up.

TASK [openshift_on_openstack_secgroup : Create the security group rule that allows uperf tests (UDP)] ***
task path: /home/slave3/workspace/scale-ci_install_OpenShift/roles/openshift_on_openstack_secgroup/tasks/main.yml:26
Friday 23 March 2018  16:40:00 +0000 (0:00:01.735)       1:21:51.786 ********** 
changed: [b03-h01-1029p.rdu.openstack.engineering.redhat.com] => {"changed": true, "cmd": "source /home/stack/overcloudrc; /usr/bin/openstack security group rule create --ingress --protocol udp --dst-port 1024:65535 openshift-ansible-scale-ci.example.com-common-secgrp", "delta": "0:00:01.398537", "end": "2018-03-23 16:40:02.131075", "failed_when_result": false, "rc": 0, "start": "2018-03-23 16:40:00.732538", "stderr": "", "stderr_lines": [], "stdout": "+-------------------+--------------------------------------+\n| Field             | Value                                |\n+-------------------+--------------------------------------+\n| created_at        | 2018-03-23T16:40:02Z                 |\n| description       |                                      |\n| direction         | ingress                              |\n| ether_type        | IPv4                                 |\n| id                | a4312961-5bc7-4676-a809-73b76e085c73 |\n| name              | None                                 |\n| port_range_max    | 65535                                |\n| port_range_min    | 1024                                 |\n| project_id        | 61d30c9293b0494abf02f2339b8f6b51     |\n| protocol          | udp                                  |\n| remote_group_id   | None                                 |\n| remote_ip_prefix  | 0.0.0.0/0                            |\n| revision_number   | 1                                    |\n| security_group_id | b9152e1c-c489-4dc3-831a-078c73ce381a |\n| updated_at        | 2018-03-23T16:40:02Z                 |\n+-------------------+--------------------------------------+", "stdout_lines": ["+-------------------+--------------------------------------+", "| Field             | Value                                |", "+-------------------+--------------------------------------+", "| created_at        | 2018-03-23T16:40:02Z                 |", "| description       |                                      |", "| direction         | ingress                              |", "| ether_type        | IPv4                                 |", "| id                | a4312961-5bc7-4676-a809-73b76e085c73 |", "| name              | None                                 |", "| port_range_max    | 65535                                |", "| port_range_min    | 1024                                 |", "| project_id        | 61d30c9293b0494abf02f2339b8f6b51     |", "| protocol          | udp                                  |", "| remote_group_id   | None                                 |", "| remote_ip_prefix  | 0.0.0.0/0                            |", "| revision_number   | 1                                    |", "| security_group_id | b9152e1c-c489-4dc3-831a-078c73ce381a |", "| updated_at        | 2018-03-23T16:40:02Z                 |", "+-------------------+--------------------------------------+"]}

The table does not need to be printed in these two cases. And using "ignore_errors" rather than failed: False