### PR TITLE
Use the remaining disk space on ansible-host for Pbench.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -31,5 +31,6 @@
     - vars/openstack.yml
     - vars/openshift.yml
   roles:
+    - pbench_storage
     - openshift_dns
     - openshift_on_openstack

--- a/roles/pbench_storage/tasks/main.yml
+++ b/roles/pbench_storage/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+# TODO: Use the ansible parted module when it can figure out the defaults by its own.
+#- name: Partition the device
+#  parted:
+#    device: /dev/vda
+#    number: "{{ pbench_storage_device_partition }}"
+#    state: present
+#  become: true
+
+- name: Adding primary partition 3 to {{ pbench_storage_device }}
+  shell: "echo -e 'n\np\n3\n\n\nw\n' | fdisk {{ pbench_storage_device }}"
+  args:
+    executable: /bin/bash
+  become: yes
+  ignore_errors: yes
+
+- name: partprobe
+  command: "partprobe {{ pbench_storage_device }}"
+  become: yes
+
+- name: Creating an xfs filesystem on {{ pbench_storage_device }}{{ pbench_storage_device_partition }}
+  command: "mkfs.xfs -f {{ pbench_storage_device }}{{ pbench_storage_device_partition }}"
+  become: yes
+
+- name: Creating an entry in fstab and mounting {{ pbench_storage_device }}{{ pbench_storage_device_partition }}
+  mount:
+    path: "{{ pbench_storage_mount_path }}"
+    src: "{{ pbench_storage_device }}{{ pbench_storage_device_partition }}"
+    fstype: xfs
+    state: mounted
+  become: yes

--- a/roles/pbench_storage/vars/main.yml
+++ b/roles/pbench_storage/vars/main.yml
@@ -1,0 +1,7 @@
+---
+# A block device to use as pbench storage.
+pbench_storage_device: '/dev/vda'
+# A partition on {{ pbench_storage_device }} to use.
+pbench_storage_device_partition: 3
+# Pbench agent default directory.
+pbench_storage_mount_path: '/var/lib/pbench-agent'


### PR DESCRIPTION
This role adds support for using the remaining disk space on a given storage device for Pbench data.  Ideally, not only ansible-host should use it, but the remaining core cluster too (TODO).