### PR TITLE
Fix: prepare images only when openstack_upload_images is set.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Find and prepare the virtual machine images
+  vars_files:
+    - vars/openstack.yml
   hosts: image-server
   roles:
     - { role: image_preparation, when: openstack_upload_images | default(True) | bool }


### PR DESCRIPTION
openstack_upload_images is defined in vars/openstack.yml.  @mbruzek, I'm including vars/openstack.yml for this role to fix the problem.  If you're uneasy about including the vars, we can always split them.  Feel free to do that if you think it is a good idea.