### PR TITLE
Support for patches to files across the filesystem.

### DIFF
--- a/roles/openshift_ansible_patch/files/20-parametrize_security_groups.patch
+++ b/roles/openshift_ansible_patch/files/20-parametrize_security_groups.patch
@@ -180,8 +180,8 @@
 +    remote_ip_prefix: "{{ openshift_openstack_lb_ingress_cidr }}"
 diff --git a/roles/openshift_openstack/templates/heat_stack.yaml.j2 b/roles/openshift_openstack/templates/heat_stack.yaml.j2
 index f2599305d..ab02e9f00 100644
---- a/roles/openshift_openstack/templates/heat_stack.yaml.j2
-+++ b/roles/openshift_openstack/templates/heat_stack.yaml.j2
+--- openshift-ansible.orig/roles/openshift_openstack/templates/heat_stack.yaml.j2
++++ openshift-ansible/roles/openshift_openstack/templates/heat_stack.yaml.j2
 @@ -145,15 +145,7 @@ resources:
            template: Basic ssh/icmp security group for cluster_id OpenShift cluster
            params:

--- a/roles/openshift_ansible_patch/files/root/01-shade-6040b34.patch
+++ b/roles/openshift_ansible_patch/files/root/01-shade-6040b34.patch
@@ -1,0 +1,37 @@
+From 6040b343455dbab426d8512ea16c7f2d0e446eee Mon Sep 17 00:00:00 2001
+From: Antoni Segura Puimedon <antonisp@celebdor.com>
+Date: Fri, 23 Mar 2018 18:31:29 +0100
+Subject: [PATCH] list_servers pagination support
+
+If we want to list the servers of a deployment with more servers than
+nova.conf max_limit, currently we only return max_limit. This patch
+makes it behave as expected, getting you all the servers.
+
+Change-Id: I58844125ba37d81f1611e4e8ec641c1b8573884d
+Signed-off-by: Antoni Segura Puimedon <antonisp@celebdor.com>
+---
+
+--- /usr/lib/python2.7/site-packages.orig/shade/openstackcloud.py
++++ /usr/lib/python2.7/site-packages/shade/openstackcloud.py
+@@ -2191,8 +2191,20 @@
+             params['all_tenants'] = True
+         data = self._compute_client.get(
+             '/servers/detail', params=params, error_message=error_msg)
++        unprocessed_servers = {'servers': []}
++        while 'servers_links' in data:
++            unprocessed_servers['servers'].extend(data['servers'])
++            parse_result = urllib.parse.urlparse(
++                data['servers_links'][0]['href'])
++            pagination_params = dict(
++                urllib.parse.parse_qsl(parse_result.query))
++            params.update(pagination_params)
++            data = self._compute_client.get(
++                '/servers/detail', params=params, error_message=error_msg)
++        unprocessed_servers['servers'].extend(data['servers'])
++
+         servers = self._normalize_servers(
+-            self._get_and_munchify('servers', data))
++            self._get_and_munchify('servers', unprocessed_servers))
+         return [
+             self._expand_server(server, detailed, bare)
+             for server in servers

--- a/roles/openshift_ansible_patch/tasks/main.yml
+++ b/roles/openshift_ansible_patch/tasks/main.yml
@@ -1,8 +1,17 @@
 ---
-- name: Apply patches to openshift-ansible
+- name: Applying patches to files in {{ ansible_user_dir }} directory
   patch:
     src: "{{ item }}"
-    basedir: openshift-ansible
-    strip: 1
-  with_fileglob:
-    - "*.patch"
+    basedir: "{{ ansible_user_dir }}"
+    strip: 0
+  with_items:
+    - "{{ lookup('fileglob', '*.patch').split(',') | sort }}"
+
+- name: Applying patches to files across the filesystem with elevated privileges
+  patch:
+    src: "{{ item }}"
+    basedir: /
+    strip: 0
+  with_items:
+    - "{{ lookup('fileglob', 'root/*.patch').split(',') | sort }}"
+  become: true


### PR DESCRIPTION
This PR adds support for patching files across the entire filesystem with elevated privileges.  It also changes the way regular (non-privileged) patches in ansible-user directory are applied.  Previously, they were applied to openshift-ansible only, now, they can be applied to any file in ansible-user
directory.

/cc @mbruzek 