### PR TITLE
Need to use keystonerc for the jump host openstackrc does not exist.

### DIFF
--- a/roles/openshift_get_core_cluster/vars/main.yml
+++ b/roles/openshift_get_core_cluster/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 # The path to the OpenStack RC file on the openstack-server, may be named differently than other servers.
-openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/overcloudrc', true) }}"
+openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/keystonerc', true) }}"


### PR DESCRIPTION
Install failed: 
```
TASK [openshift_get_core_cluster : Getting the list of hosts from OpenStack] ***
task path: /home/slave4/workspace/scale-ci_install_OpenShift/roles/openshift_get_core_cluster/tasks/main.yml:26
Monday 16 April 2018  19:53:31 +0000 (0:00:00.022)       0:47:38.866 ********** 
fatal: [172.21.0.101]: FAILED! => {"changed": false, "cmd": "source /home/cloud-user/overcloudrc; /usr/bin/openstack server list --name .*-[0-9]*.scale-ci.example.com --format value -c Name -c Networks --limit -1", "delta": "0:00:00.003361", "end": "2018-04-16 15:53:31.491076", "failed": true, "rc": 1, "start": "2018-04-16 15:53:31.487715", "stderr": "/bin/sh: /home/cloud-user/overcloudrc: No such file or directory", "stderr_lines": ["/bin/sh: /home/cloud-user/overcloudrc: No such file or directory"], "stdout": "", "stdout_lines": []}
	to retry, use: --limit @/home/slave4/workspace/scale-ci_install_OpenShift/playbook.retry
```

This PR should fix the error listed above.