### PR TITLE
Give sufficient storage to Pbench on the core OCP cluster.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -36,7 +36,20 @@
     - pbench_storage
     - openshift_dns
     - openshift_on_openstack
+
+- name: Find the core cluster and add it to the in-memory inventory
+  hosts: openstack-server
+  vars_files:
+    - vars/openstack.yml
+  roles:
     - openshift_get_core_cluster
+
+- name: Use the remaining disk space on the core cluster for Pbench
+  hosts: masters infras lb cns app_nodes
+  vars_files:
+    - vars/openstack.yml
+  roles:
+    - pbench_storage
 
 - name: Add IP address of the core OCP cluster to /etc/hosts on target-server
   hosts: target-server

--- a/roles/openshift_get_core_cluster/tasks/main.yml
+++ b/roles/openshift_get_core_cluster/tasks/main.yml
@@ -51,6 +51,7 @@
     name: "{{ item.name }}"
     groups: [ "{{ item.group }}" ]
     ansible_user: openshift
+    ansible_host: "{{ item.public_ip }}"
     ansible_ssh_common_args: "-o ProxyCommand='{{ proxy_command }}'"
     public_ip: "{{ item.public_ip }}"
     private_ip: "{{ item.private_ip }}"

--- a/roles/openshift_get_core_cluster/vars/main.yml
+++ b/roles/openshift_get_core_cluster/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 # The path to the OpenStack RC file on the openstack-server, may be named differently than other servers.
-openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/keystonerc', true) }}"
+openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/overcloudrc', true) }}"


### PR DESCRIPTION
This PR uses the remaining disk space on the core OCP cluster for Pbench.