### PR TITLE
Allow root login to OCP cluster nodes.

### DIFF
--- a/roles/openshift_on_openstack/templates/all.yml.cfg.j2
+++ b/roles/openshift_on_openstack/templates/all.yml.cfg.j2
@@ -5,6 +5,7 @@ openshift_openstack_keypair_name: "{{ openstack_keypair_name }}"
 openshift_openstack_external_network_name: "{{ openstack_public_network_name }}"
 openshift_openstack_default_image_name: "{{ virtual_image_name }}"
 openshift_openstack_use_vm_load_balancer: true
+openshift_openstack_disable_root: false
 openshift_openstack_num_masters: 3
 openshift_openstack_num_infra: 3
 openshift_openstack_num_cns: 3


### PR DESCRIPTION
This is a current requirement for Pbench setup.