### PR TITLE
Add EFK logging stack to core install

### DIFF
--- a/roles/openshift_on_openstack/templates/OSEv3.yml.cfg.j2
+++ b/roles/openshift_on_openstack/templates/OSEv3.yml.cfg.j2
@@ -49,6 +49,18 @@ openshift_prometheus_storage_class: "glusterfs-storage-block"
 openshift_prometheus_storage_type: pvc
 openshift_prometheus_storage_volume_size: 40Gi
 
+# EFK logging stack variables
+openshift_logging_install_logging: true
+openshift_logging_es_cluster_size: 3
+openshift_logging_es_pvc_dynamic: true
+openshift_logging_es_pvc_size: 50Gi
+openshift_logging_es_pvc_storage_class_name: "gluster-storage-block"
+openshift_logging_fluentd_read_from_head: false
+openshift_logging_use_mux: false
+openshift_logging_curator_nodeselector: {"region": "infra"}
+openshift_logging_kibana_nodeselector: {"region": "infra"}
+openshift_logging_es_nodeselector: {"region": "infra"}
+
 # Disable cockpit.
 osm_use_cockpit: false
 
@@ -74,6 +86,8 @@ openshift_prometheus_alertmanager_image_prefix: {{ registries[0] }}/openshift3/
 openshift_prometheus_alertmanager_image_version: v{{ ocp_major_minor }}
 openshift_prometheus_alertbuffer_image_prefix: {{ registries[0] }}/openshift3/
 openshift_prometheus_alertbuffer_image_version: v{{ ocp_major_minor }}
+openshift_logging_image_prefix: {{ registries[0] }}/openshift3/
+openshift_logging_image_version: v{{ ocp_major_minor }}
 ansible_service_broker_image_prefix: {{ registries[0] }}/openshift3/ose-
 ansible_service_broker_image_tag: v{{ ocp_major_minor }}
 template_service_broker_prefix: {{ registries[0] }}/openshift3/ose-


### PR DESCRIPTION
Addresses https://trello.com/c/uOO0VkiA/689-3scale-ci-ensure-logging-is-always-deployed

@mbruzek @jmencak PTAL.   Any good way to test this?   I tested on AWS with gp2 storage - there is a fluentd issue (https://bugzilla.redhat.com/show_bug.cgi?id=1569106) but not related to this install config.

@ekuric is 50GB x 3 an acceptable amount of glusterblock to consume?