### PR TITLE
Use internal Pbench server to send results to.

### DIFF
--- a/roles/pbench_storage/tasks/main.yml
+++ b/roles/pbench_storage/tasks/main.yml
@@ -29,3 +29,9 @@
     fstype: xfs
     state: mounted
   become: yes
+
+- name: Creating Pbench agent config
+  template:
+    src: pbench-agent.cfg.j2
+    dest: /opt/pbench-agent/config/pbench-agent.cfg
+  become: yes

--- a/roles/pbench_storage/templates/pbench-agent.cfg.j2
+++ b/roles/pbench_storage/templates/pbench-agent.cfg.j2
@@ -1,0 +1,52 @@
+[DEFAULT]
+pbench_install_dir = /opt/pbench-agent
+# CHANGE ME1!
+pbench_results_redirector = {{ pbench_results_redirector }}
+# CHANGE ME2!
+pbench_web_server = {{ pbench_web_server }}
+
+[pbench-agent]
+install-dir = %(pbench_install_dir)s
+pbench_user = pbench
+pbench_group = pbench
+pbench_run = /var/lib/pbench-agent
+pbench_log = %(pbench_run)s/pbench.log
+
+[results]
+user = pbench
+host_path = http://%(pbench_result_redirector)s/pbench-archive-host
+ssh_opts = -o StrictHostKeyChecking=no
+scp_opts = -o StrictHostKeyChecking=no
+webserver = %(pbench_web_server)s
+host_info_url = http://%(webserver)s/pbench-results-host-info.versioned/pbench-results-host-info.URL001
+dir = /pbench/public_html/incoming
+
+[pbench/tools]
+default-tool-set = sar, iostat, mpstat, pidstat, proc-vmstat, proc-interrupts, turbostat
+interval = 3
+
+[tools/pidstat]
+interval = 30
+
+[packages]
+# If you install using an "internal" RPM, that should
+# take care of installing the right package, depending
+# on the distro.
+
+# If you are copying this example file to create the "real"
+# pbench-agent.cfg file, you need to uncomment one of the
+# following pandas-package lines.
+# RHEL has python-pandas
+pandas-package = python-pandas
+# Fedora has python2-pandas and python3-pandas
+# pandas-package = python2-pandas
+
+[config]
+path = %(pbench_install_dir)s/config
+# BEGIN ANSIBLE MANAGED BLOCK
+[pbench-fio]
+version = 3.3
+histogram_interval_msec = 10000
+# END ANSIBLE MANAGED BLOCK
+files = pbench-agent.cfg
+

--- a/roles/pbench_storage/vars/main.yml
+++ b/roles/pbench_storage/vars/main.yml
@@ -5,3 +5,7 @@ pbench_storage_device: '/dev/vda'
 pbench_storage_device_partition: 3
 # Pbench agent default directory.
 pbench_storage_mount_path: '/var/lib/pbench-agent'
+# Pbench results redirector host.
+pbench_results_redirector: 'pbench.perf.lab.eng.bos.redhat.com'
+# Pbench web server host.
+pbench_web_server: '{{ pbench_results_redirector }}'


### PR DESCRIPTION
This PR allows pbench-copy/move-results work out of the box on ansible-host.