### PR TITLE
Increase the default number of application nodes to 4.

### DIFF
--- a/vars/openshift.yml
+++ b/vars/openshift.yml
@@ -12,4 +12,4 @@ openshift_default_flavor: "{{ lookup('env', 'openshift_default_flavor')|default(
 # The flavor to use for the OpenShift nodes.
 openshift_node_flavor: "{{ lookup('env', 'openshift_node_flavor')|default('node_large', true) }}"
 # Get the number of OpenShift nodes to scale to.
-openshift_node_target: "{{ lookup('env', 'OPENSHIFT_NODE_TARGET') | default(2, true) }}"
+openshift_node_target: "{{ lookup('env', 'OPENSHIFT_NODE_TARGET') | default(4, true) }}"


### PR DESCRIPTION
Increasing the default size of the core cluster so that basic tests can be run without an additional scaleup. @chaitanyaenr , ptal.