### PR TITLE
Support for optionally cloning openshift-ansible repository.

### DIFF
--- a/roles/openshift_on_openstack/tasks/main.yml
+++ b/roles/openshift_on_openstack/tasks/main.yml
@@ -34,7 +34,7 @@
   # Note: The copy module does not support recursive copy of remote sources.
   command: "cp -a /root/openshift-ansible/ {{ ansible_user_dir }}/openshift-ansible"
   become: true
-  when: openshift_ansible['stat']['exists']
+  when: (not openshift_ansible_clone | bool) and openshift_ansible['stat']['exists']
 
 # Change the permissions to be owned by the user.
 - name: Changing the permission of the openshift-ansible files
@@ -44,13 +44,13 @@
     group: "{{ ansible_user }}"
     recurse: yes
   become: true
-  when: openshift_ansible['stat']['exists']
+  when: (not openshift_ansible_clone | bool) and openshift_ansible['stat']['exists']
 
 # Print the values that will be used for the openshift-ansible repository.
 - name: Printing the values used to clone openshift-ansible
   debug:
     msg: "openshift-ansible repository: {{ openshift_ansible_repo }} {{ openshift_ansible_version }}"
-  when: openshift_ansible['stat']['exists'] == false
+  when: openshift_ansible_clone | bool
 
 # Get a fresh clone of the openshift-ansible GitHub project.
 - name: Cloning the openshift-ansible repository
@@ -60,7 +60,7 @@
     repo: "{{ openshift_ansible_repo }}"
     # Specify a version for a different branch, tag, or hash to verify PRs.
     version: "{{ openshift_ansible_version }}"
-  when: openshift_ansible['stat']['exists'] == false
+  when: openshift_ansible_clone | bool
 
 # Include the tasks from the openshift_ansible_patch role.
 - name: Include the tasks to patch files in the openshift-ansible directory

--- a/roles/openshift_on_openstack/vars/main.yml
+++ b/roles/openshift_on_openstack/vars/main.yml
@@ -15,3 +15,5 @@ openshift_registries: "{{ lookup('env', 'openshift_registries') }}"
 openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/keystonerc', true) }}"
 # Break up the space separate string into a list of image registries for the OSEv3.yml variables.
 registries: "{{ openshift_registries.split(' ') }}"
+# Clone openshift-ansible repository rather than copying /root/openshift-ansible
+openshift_ansible_clone: "{{ lookup('env', 'openshift_ansible_clone')|default(false, true) }}"


### PR DESCRIPTION
Optional support for git cloning openshift-ansible repository.  By default /root/openshift-ansible is used, unless openshift_ansible_clone is set true.