### PR TITLE
Need to make all the OpenShift flavors configurable.

### DIFF
--- a/files/get_controller_logs.yml
+++ b/files/get_controller_logs.yml
@@ -7,6 +7,7 @@
     local_destination_directory: "{{ lookup('env', 'PWD')|default('.', true) }}"
     # The OpenStack controller services to capture the logs.
     openstack_controller_services:
+      - glance
       - heat
       - neutron
       - nova

--- a/roles/openshift_on_openstack/templates/all.yml.cfg.j2
+++ b/roles/openshift_on_openstack/templates/all.yml.cfg.j2
@@ -10,11 +10,11 @@ openshift_openstack_num_masters: 3
 openshift_openstack_num_infra: 3
 openshift_openstack_num_cns: 3
 openshift_openstack_num_nodes: "{{ openshift_node_target }}"
-openshift_openstack_master_flavor: "master_etcd"
-openshift_openstack_infra_flavor: "infra_elastic"
-openshift_openstack_cns_flavor: "container_storage"
+openshift_openstack_master_flavor: "{{ openshift_master_flavor }}"
+openshift_openstack_infra_flavor: "{{ openshift_infra_flavor }}"
+openshift_openstack_cns_flavor: "{{ openshift_cns_flavor }}"
 openshift_openstack_node_flavor: "{{ openshift_node_flavor }}"
-openshift_openstack_lb_flavor: "load_balancer"
+openshift_openstack_lb_flavor: "{{ openshift_lb_flavor }}"
 openshift_openstack_default_flavor: "{{ openshift_default_flavor }}"
 openshift_openstack_subnet_cidr: "192.168.96.0/20"
 openshift_openstack_pool_start: "192.168.96.3"

--- a/roles/openstack_create_server/vars/main.yml
+++ b/roles/openstack_create_server/vars/main.yml
@@ -24,9 +24,10 @@ openshift_flavors:
   - { name: load_balancer, vcpu: 4, memory: 16384, disk: 128 }
   - { name: infra_elastic, vcpu: 40, memory: 163840, disk: 128, property: '--property "pci_passthrough:alias"="nvme:1"' }
   - { name: master_etcd, vcpu: 16, memory: 124928, disk: 256, property: '--property "pci_passthrough:alias"="nvme:1"' }
-  - { name: node_small, vcpu: 1, memory: 2048, disk: 71 }
-  - { name: node_medium, vcpu: 4, memory: 16384, disk: 96 }
-  - { name: node_large, vcpu: 8, memory: 31744, disk: 128 }
+  - { name: node_minimum, vcpu: 1, memory: 2048, disk: 71 }
+  - { name: node_small, vcpu: 2, memory: 8192, disk: 96 }
+  - { name: node_medium, vcpu: 4, memory: 16384, disk: 128 }
+  - { name: node_large, vcpu: 8, memory: 31744, disk: 160 }
 # The path to the OpenStack RC file on the openstack-server, may be named differently than other servers.
 openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/overcloudrc', true) }}"
 # The path to the private key, put it the install directory for easy cleanup.

--- a/vars/openshift.yml
+++ b/vars/openshift.yml
@@ -7,9 +7,17 @@ openshift_ansible_version: "{{ lookup('env', 'openshift_ansible_version')|defaul
 openshift_ansible_contrib_repo: "{{ lookup('env', 'openshift_ansible_contrib_repo')|default('https://github.com/openshift/openshift-ansible-contrib', true) }}"
 # This version can be a branch, tag, or hash for testing pull requests.
 openshift_ansible_contrib_version: "{{ lookup('env', 'openshift_ansible_contrib_version')|default('master', true) }}"
+# The flavor to use for OpenShift CNS VMs.
+openshift_cns_flavor: "{{ lookup('env', 'openshift_cns_flavor')|default('container_storage', true) }}"
 # The flavor to use as default for other OpenShift VMs.
 openshift_default_flavor: "{{ lookup('env', 'openshift_default_flavor')|default('m1.medium', true) }}"
-# The flavor to use for the OpenShift nodes.
+# The flavor to use for OpenShift infra VMs.
+openshift_infra_flavor: "{{ lookup('env', 'openshift_infra_flavor')|default('infra_elastic', true)}}"
+# The flavor to use for OpenShift load balancer VMs.
+openshift_lb_flavor: "{{ lookup('env', 'openshift_lb_flavor')|default('load_balancer', true) }}"
+# The flavor to use for OpenShift master VMs.
+openshift_master_flavor: "{{ lookup('env', 'openshift_master_flavor')|default('master_etcd', true) }}"
+# The flavor to use for OpenShift node VMs.
 openshift_node_flavor: "{{ lookup('env', 'openshift_node_flavor')|default('node_large', true) }}"
 # Get the number of OpenShift nodes to scale to.
 openshift_node_target: "{{ lookup('env', 'OPENSHIFT_NODE_TARGET') | default(2, true) }}"


### PR DESCRIPTION
Adding a new node flavor and changing disk sizes.

The staging environment can not fit an OpenShift cluster with the existing flavor sizes. This PR makes the flavors for the other OpenShift roles configurable but defaults to the same flavors.
