### PR TITLE
Use the Allow All Identity Provider to pass e2e.

### DIFF
--- a/roles/openshift_on_openstack/templates/OSEv3.yml.cfg.j2
+++ b/roles/openshift_on_openstack/templates/OSEv3.yml.cfg.j2
@@ -11,10 +11,8 @@ openshift_clock_enabled: true
 # Enable cluster metrics.
 use_cluster_metrics: true
 
-# Allow authentication using an Apache HTTP server authentication file.
-openshift_master_identity_providers: [{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
-# Defining htpasswd users
-openshift_master_htpasswd_users: {'admin': 'admin', 'test': 'test'}
+# Use the allow all identity provider for conformance tests.
+openshift_master_identity_providers: [{'name': 'allow_all', 'login': 'true', 'challenge': 'true', 'kind': 'AllowAllPasswordIdentityProvider'}]
 
 # Configure how often node iptables rules are refreshed.
 openshift_node_iptables_sync_period: 30s


### PR DESCRIPTION
On the latest deploy I got an error about the "filename" key in the Htpasswd Identity Provider.
"failed provider HTPasswdPasswordIdentityProvider contains unknown keys filename"

We need to use Allow All Identity provider to pass conformance tests.

