### PR TITLE
Label the application nodes after the core cluster is up

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -59,3 +59,4 @@
     - openshift_copy_kube_config
     - openstack_etc_hosts
     - jenkins_pipeline
+    - openshift_label_nodes

--- a/roles/openshift_label_nodes/tasks/main.yml
+++ b/roles/openshift_label_nodes/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: label the application nodes in the core cluster
+  shell: oc label node {{ item }}.{{ clusterid }}.{{ dns_domain }} {{ label }}
+  with_items:
+    - "{{ groups['app_nodes'] }}"

--- a/roles/openshift_label_nodes/vars/main.yml
+++ b/roles/openshift_label_nodes/vars/main.yml
@@ -1,0 +1,2 @@
+---
+label: core_app_node=true


### PR DESCRIPTION
This is needed to differentiate between the app nodes belonging to
the core cluster and scaled up cluster.