### PR TITLE
Set master cluster public hostname and default subdomain.

### DIFF
--- a/roles/openshift_on_openstack/templates/OSEv3.yml.cfg.j2
+++ b/roles/openshift_on_openstack/templates/OSEv3.yml.cfg.j2
@@ -14,6 +14,10 @@ use_cluster_metrics: true
 # Use the allow all identity provider for conformance tests.
 openshift_master_identity_providers: [{'name': 'allow_all', 'login': 'true', 'challenge': 'true', 'kind': 'AllowAllPasswordIdentityProvider'}]
 
+# Set master cluster public hostname and default subdomain for exposed routes
+openshift_master_cluster_public_hostname: lb-0.{{ clusterid }}.{{ dns_domain }}
+openshift_master_default_subdomain: apps.{{ clusterid }}.{{ dns_domain }}
+
 # Configure how often node iptables rules are refreshed.
 openshift_node_iptables_sync_period: 30s
 


### PR DESCRIPTION
Set master cluster public hostname and default subdomain for exposed routes.  By default openshift_master_cluster_public_hostname points to console.{{ clusterid }}.{{ dns_domain }}, not lb-0.{{ clusterid }}.{{ dns_domain }}.