### PR TITLE
Only use EC2 flavors and create pci passthrough versions.

### DIFF
--- a/roles/openstack_create_server/tasks/main.yml
+++ b/roles/openstack_create_server/tasks/main.yml
@@ -131,10 +131,18 @@
 - name: Creating {{ openstack_keypair_name }} keypair to access this server
   shell: "{{ openstack }} keypair create --public-key {{ remote_public_key_path }} {{ openstack_keypair_name }} --format value -c fingerprint"
 
-# Create the flavors so the create server can specify a flavor.
-- name: Creating the flavors
-  shell: "{{ openstack }} flavor create --ram {{ item['memory'] }} --disk {{ item['disk'] }} --vcpus {{ item['vcpu'] }} {{ item['property']|default('') }} {{ item['name'] }} --format value -c id"
-  with_items: "{{ ec2_flavors }} + {{ standard_flavors }} + {{ openshift_flavors }}"
+# Create EC2 flavors so create server can specify a standard size.
+- name: Creating the EC2 flavors
+  shell: "{{ openstack }} flavor create --ram {{ item['memory'] }} --disk {{ item['disk'] }} --vcpus {{ item['vcpu'] }} {{ item['name'] }} --format value -c id"
+  with_items: "{{ ec2_flavors }}"
+  # Some OpenStack environments do not allow users to create public flavors.
+  ignore_errors: true
+  when: openstack_create_flavors | default(True) | bool
+
+# Create PCI flavors so create server can specify a pci passthrough size.
+- name: Creating the PCI passthrough flavors
+  shell: "{{ openstack }} flavor create --ram {{ item['memory'] }} --disk {{ item['disk'] }} --vcpus {{ item['vcpu'] }} --property {{ pci_passthrough_property }} {{ item['name'] }}-pci --format value -c id"
+  with_items: "{{ ec2_flavors }}"
   # Some OpenStack environments do not allow users to create public flavors.
   ignore_errors: true
   when: openstack_create_flavors | default(True) | bool

--- a/roles/openstack_create_server/vars/main.yml
+++ b/roles/openstack_create_server/vars/main.yml
@@ -6,30 +6,24 @@ ec2_flavors:
   - { name: m1.medium, vcpu: 1, memory: 3840, disk: 96 }
   - { name: m1.large, vcpu: 2, memory: 7680, disk: 128 }
   # https://aws.amazon.com/ec2/instance-types/#m4
-  - { name: m4.large, vcpu: 2, memory: 8192, disk: 100 }
-  - { name: m4.xlarge, vcpu: 4, memory: 16384, disk: 200 }
-  - { name: m4.2xlarge, vcpu: 8, memory: 32768, disk: 300 }
-  - { name: m4.4xlarge, vcpu: 16, memory: 65536, disk: 400 }
-  - { name: m4.10xlarge, vcpu: 40, memory: 163840, disk: 500 }
+  # The RAM values are reduced by 256 MB to fit better on hosts.
+  - { name: m4.large, vcpu: 2, memory: "{{ 8192 - 256 }}", disk: 96 }
+  - { name: m4.xlarge, vcpu: 4, memory: "{{ 16384 - 256 }}", disk: 96 }
+  - { name: m4.2xlarge, vcpu: 8, memory: "{{ 32768 - 256 }}", disk: 128 }
+  - { name: m4.4xlarge, vcpu: 16, memory: "{{ 65536 - 256 }}", disk: 128 }
+  - { name: m4.10xlarge, vcpu: 40, memory: "{{ 163840 - 256 }}", disk: 256 }
   # https://aws.amazon.com/ec2/instance-types/#r4
-  - { name: r4.large, vcpu: 2, memory: 15616, disk: 71 }
-  - { name: r4.xlarge, vcpu: 4, memory: 31232, disk: 71 }
-  - { name: r4.2xlarge, vcpu: 8, memory: 62464, disk: 96 }
-  - { name: r4.4xlarge, vcpu: 16, memory: 124928, disk: 128 }
-  - { name: r4.8xlarge, vcpu: 32, memory: 249856, disk: 256 }
-  - { name: r4.16xlarge, vcpu: 64, memory: 499712, disk: 512 }
-# The OpenShift flavors for the different roles.
-openshift_flavors:
-  - { name: container_storage, vcpu: 16, memory: 65536, disk: 128, property: '--property "pci_passthrough:alias"="nvme:1"' }
-  - { name: load_balancer, vcpu: 4, memory: 16384, disk: 128 }
-  - { name: infra_elastic, vcpu: 40, memory: 163840, disk: 128, property: '--property "pci_passthrough:alias"="nvme:1"' }
-  - { name: master_etcd, vcpu: 16, memory: 124928, disk: 256, property: '--property "pci_passthrough:alias"="nvme:1"' }
-  - { name: node_minimum, vcpu: 1, memory: 2048, disk: 71 }
-  - { name: node_small, vcpu: 2, memory: 8192, disk: 96 }
-  - { name: node_medium, vcpu: 4, memory: 16384, disk: 128 }
-  - { name: node_large, vcpu: 8, memory: 31744, disk: 160 }
+  # The RAM values are reduced by 256 MB to fit better on hosts.
+  - { name: r4.large, vcpu: 2, memory: "{{ 15616 - 256 }}", disk: 71 }
+  - { name: r4.xlarge, vcpu: 4, memory: "{{ 31232 - 256 }}", disk: 71 }
+  - { name: r4.2xlarge, vcpu: 8, memory: "{{ 62464 - 256 }}", disk: 96 }
+  - { name: r4.4xlarge, vcpu: 16, memory: "{{ 124928 - 256 }}", disk: 128 }
+  - { name: r4.8xlarge, vcpu: 32, memory: "{{ 249856 - 256 }}", disk: 256 }
+  - { name: r4.16xlarge, vcpu: 64, memory: "{{ 499712 - 256 }}", disk: 512 }
 # The path to the OpenStack RC file on the openstack-server, may be named differently than other servers.
 openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/overcloudrc', true) }}"
+# The flavor property name and value to indicate the device for PCI passthrough.
+pci_passthrough_property: '"pci_passthrough:alias"="nvme:1"'
 # The path to the private key, put it the install directory for easy cleanup.
 remote_private_key_path: "{{ lookup('env', 'remote_private_key_path')|default(install_directory ~ '/key.private', true) }}"
 # The path to the public key, put it in the install directory for easy cleanup.
@@ -60,14 +54,3 @@ quotas:
   snapshots: -1       # Volume snapshots allowed for each project.
   subnets: -1
   volumes: -1         # Volumes allowed for each project.
-
-# Rough equivalents of the Google cloud instance sizes.
-standard_flavors:
-  # https://cloud.google.com/compute/docs/machine-types
-  - { name: n1-standard-1, vcpu: 1, memory: 3750, disk: 71 }
-  - { name: n1-standard-2, vcpu: 2, memory: 7500, disk: 80 }
-  - { name: n1-standard-4, vcpu: 4, memory: 15000, disk: 80 }
-  - { name: n1-standard-8, vcpu: 8, memory: 30000, disk: 100 }
-  - { name: n1-standard-16, vcpu: 16, memory: 60000, disk: 100 }
-  - { name: n1-standard-32, vcpu: 32, memory: 120000, disk: 200 }
-  - { name: n1-standard-64, vcpu: 64, memory: 240000, disk: 200 }

--- a/vars/openshift.yml
+++ b/vars/openshift.yml
@@ -8,16 +8,16 @@ openshift_ansible_contrib_repo: "{{ lookup('env', 'openshift_ansible_contrib_rep
 # This version can be a branch, tag, or hash for testing pull requests.
 openshift_ansible_contrib_version: "{{ lookup('env', 'openshift_ansible_contrib_version')|default('master', true) }}"
 # The flavor to use for OpenShift CNS VMs.
-openshift_cns_flavor: "{{ lookup('env', 'openshift_cns_flavor')|default('container_storage', true) }}"
+openshift_cns_flavor: "{{ lookup('env', 'openshift_cns_flavor')|default('m4.4xlarge-pci', true) }}"
 # The flavor to use as default for other OpenShift VMs.
 openshift_default_flavor: "{{ lookup('env', 'openshift_default_flavor')|default('m1.medium', true) }}"
 # The flavor to use for OpenShift infra VMs.
-openshift_infra_flavor: "{{ lookup('env', 'openshift_infra_flavor')|default('infra_elastic', true)}}"
+openshift_infra_flavor: "{{ lookup('env', 'openshift_infra_flavor')|default('m4.10xlarge-pci', true)}}"
 # The flavor to use for OpenShift load balancer VMs.
-openshift_lb_flavor: "{{ lookup('env', 'openshift_lb_flavor')|default('load_balancer', true) }}"
+openshift_lb_flavor: "{{ lookup('env', 'openshift_lb_flavor')|default('m4.xlarge', true) }}"
 # The flavor to use for OpenShift master VMs.
-openshift_master_flavor: "{{ lookup('env', 'openshift_master_flavor')|default('master_etcd', true) }}"
+openshift_master_flavor: "{{ lookup('env', 'openshift_master_flavor')|default('r4.4xlarge-pci', true) }}"
 # The flavor to use for OpenShift node VMs.
-openshift_node_flavor: "{{ lookup('env', 'openshift_node_flavor')|default('node_large', true) }}"
+openshift_node_flavor: "{{ lookup('env', 'openshift_node_flavor')|default('m4.large', true) }}"
 # Get the number of OpenShift nodes to scale to.
 openshift_node_target: "{{ lookup('env', 'OPENSHIFT_NODE_TARGET') | default(2, true) }}"


### PR DESCRIPTION
Creating aws only flavors to avoid confusion.
Creating -pci versions of the same flavors to allow VMs to use both PCI passthrough and without.