### PR TITLE
Add support to monitor openshift install and scaleup runs

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -60,3 +60,4 @@
     - openstack_etc_hosts
     - jenkins_pipeline
     - openshift_label_nodes
+    - openshift_move_run_results

--- a/roles/openshift_move_run_results/tasks/main.yml
+++ b/roles/openshift_move_run_results/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: move pbench results gathered for openshift install and scaleup runs to the pbench-server
+  shell: pbench-move-results

--- a/roles/openshift_on_openstack/tasks/main.yml
+++ b/roles/openshift_on_openstack/tasks/main.yml
@@ -280,10 +280,14 @@
   set_fact:
     openshift_install_log: "{{ ansible_user_dir }}/openshift_install.log"
 
+# Register pbench default tool-set
+- name: Register pbench toolset
+  shell: pbench-register-tool-set
+
 # Run the Ansible playbook that installs OpenShift.
 - name: Installing OpenShift on OpenStack
   # Using two inventory flags here as the README instructs.
-  shell: "{{ ansible_playbook }} -vvv --user openshift -i inventory -i {{ inventory_py }} {{ openshift_openstack_dir }}/openshift-cluster/install.yml 2>&1 >> {{ openshift_install_log }}"
+  shell: pbench-user-benchmark --pbench-post='/usr/local/bin/pbscraper -i $benchmark_results_dir/tools-default -o $benchmark_results_dir; ansible-playbook -vv -i {{ pbcompare_inventory }} {{ pbcompare_playbook }} -e \'new_file='$benchmark_results_dir/out.json'' -e \'github_token={{ pbcompare_github_token }}'' -- {{ ansible_playbook }} -vvv --user openshift -i inventory -i {{ inventory_py }} {{ openshift_openstack_dir }}/openshift-cluster/install.yml 2>&1 >> {{ openshift_install_log }}
   args:
     # Use bash to get the posix style redirects.
     executable: /bin/bash

--- a/roles/openshift_on_openstack/vars/main.yml
+++ b/roles/openshift_on_openstack/vars/main.yml
@@ -17,3 +17,9 @@ openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ 
 registries: "{{ openshift_registries.split(' ') }}"
 # Clone openshift-ansible repository rather than copying /root/openshift-ansible
 openshift_ansible_clone: "{{ lookup('env', 'openshift_ansible_clone')|default(false, true) }}"
+# Pbench analyzer inventory file
+pbcompare_inventory: /root/svt/utils/pbwedge/hosts
+# Pbench analyzer playbook
+pbcompare_playbook: /root/svt/utils/pbwedge/main.yml
+# Github token
+pbcompare_github_token: "{{ lookup('env', 'pbcompare_github_token') }}"

--- a/roles/openshift_on_openstack_scale/tasks/scaleup.yml
+++ b/roles/openshift_on_openstack_scale/tasks/scaleup.yml
@@ -105,7 +105,13 @@
 # Scale up the OpenShift cluster.
 - name: Scaling up the OpenShift resources
   shell: >
-    {{ ansible_playbook_scaleup }} -vv
+    pbench-user-benchmark
+    --pbench-post='/usr/local/bin/pbscraper
+    -i $benchmark_results_dir/tools-default
+    -o $benchmark_results_dir;
+    ansible-playbook -i {{ pbcompare_inventory }} {{ pbcompare_playbook }}
+    -e \'new_file='$benchmark_results_dir/out.json'' -e \'github_token={{ pbcompare_github_token }}''
+    -- {{ ansible_playbook_scaleup }} -vv
     --user openshift
     -i inventory/
     -i {{ inventory_py }}

--- a/roles/openshift_on_openstack_scale/vars/main.yml
+++ b/roles/openshift_on_openstack_scale/vars/main.yml
@@ -17,3 +17,9 @@ openshift_cluster_directory: "{{ ansible_user_dir }}/openshift-ansible/playbooks
 openshift_node_directory: "{{ ansible_user_dir }}/openshift-ansible/playbooks/openshift-node"
 # The path to the OpenStack RC file on the server vm, may be named differently than other servers.
 openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/keystonerc', true) }}"
+# Pbench analyzer inventory file
+pbcompare_inventory: /root/svt/utils/pbwedge/hosts
+# Pbench analyzer playbook
+pbcompare_playbook: /root/svt/utils/pbwedge/main.yml
+# Github token
+pbcompare_github_token: "{{ lookup('env', 'pbcompare_github_token') }}"


### PR DESCRIPTION
- This commit adds support to monitor openshift installation and
  scale up runs using pbench. A summary file is generated by the
  R2R tool which will help us in deciding the pass/fail in
  scale-ci-pipeline.
- This commit also adds a role to move the results to the pbench
  server.