### PR TITLE
Add the core OCP cluster to /etc/hosts on the undercloud host.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -43,6 +43,7 @@
     - vars/openstack.yml
   roles:
     - openshift_get_core_cluster
+    - openstack_etc_hosts
 
 - name: Use the remaining disk space on the core cluster for Pbench
   hosts: masters infras lb cns app_nodes


### PR DESCRIPTION
This is a temporary workaround for running conformance tests in a Jenkins
pipeline until a proper DNS solution on an OSP environment with private IPs
(provider network) is implemented.