### PR TITLE
The debug information was not correct fixing commands.

### DIFF
--- a/roles/openshift_on_openstack/tasks/main.yml
+++ b/roles/openshift_on_openstack/tasks/main.yml
@@ -232,11 +232,14 @@
 
     # Get some debug information that makes it easier to file OpenShift bugs.
     - name: Running commands that create debug information needed to open issues
-      shell: |
-        printf $(uname -srm)\n$(cat /etc/os-release)\n > debug_information.txt
-        ansible --version >> debug_information.txt
-        rpm -q atomic-openshift-utils openshift-ansible >> debug_information.txt
-        cd openshift-ansible; git describe >> debug_information.txt
+      shell: "{{ item }} >> debug_information.txt"
+      with_items:
+        - "printf \"$(uname -srm)\n$(cat /etc/os-release)\n\""
+        - "ansible --version"
+        - "cd openshift-ansible ; git describe"
+        - "rpm -q atomic-openshift-utils openshift-ansible"
+      # Ignore errors because OpenShift is either installed via rpm or github.
+      ignore_errors: true
 
     # Write the debug information to the artifacts directory.
     - name: Copy the debug information to the artifacts directory


### PR DESCRIPTION
The change to the debug information had to be partially reverted because it is not equivalent to before. The information is partial because the all in one command stopped after the rpm command returns 2.

Also the print command didn't have the required quotes and was missing most of the information after the word Linux...
```
Linuxansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/cloud-user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  4 2018, 09:38:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-34)]
package atomic-openshift-utils is not installed
package openshift-ansible is not installed
```
It should be noted these are the exact comands that the openshift-ansible team requires output from to open bugs.