### PR TITLE
Clean the yum cache in cases where needed.

### DIFF
--- a/roles/openshift_dependencies/tasks/main.yml
+++ b/roles/openshift_dependencies/tasks/main.yml
@@ -17,6 +17,13 @@
   setup:
     filter: ansible_*
 
+# In some cases the yum cache could be invalid, clean cache before installing.
+- name: Cleaning the yum cache
+  become: true
+  # Using raw, because the Python yum package may not be installed.
+  raw: rm -fr /var/cache/yum/*; yum clean all;
+  when: clean_yum_cache
+
 # Install the common operating system packages on the host.
 - name: Installing the common operating system software packages
   become: true

--- a/roles/openshift_dependencies/vars/main.yml
+++ b/roles/openshift_dependencies/vars/main.yml
@@ -1,6 +1,8 @@
 ---
 # The path to the OpenStack RC file on the server vm, may be named differently than other servers.
 openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/keystonerc', true) }}"
+# The boolean to control the cleaning of the yum cache.
+clean_yum_cache: "{{ lookup('env', 'clean_yum_cache')|default(false, true) }}"
 # A dictionary of packages to install for different families of operating systems.
 packages:
   common:


### PR DESCRIPTION
We encountered an error on the task `openshift_dependencies : Installing operating system specific software packages` where an image with an invalid yum cache could not install the software needed for openstack-ansible. This was a test image, in the regular images a cache clean is normally performed.

Error:
```
No Presto metadata available for rhel-7-next
https://mirror.openshift.com/enterprise/rhel/rhel7next/os/Packages/python-devel-2.7.5-1.el7.x86_64.rpm: [Errno 14] HTTPS Error 404 - Not Found
Trying other mirror.
To address this issue please refer to the below knowledge base article 

https://access.redhat.com/articles/1320623

If above article doesn't help to resolve this issue please open a ticket with Red Hat Support.
```

Adding tasks that can clean the cache in the automation in case we need it in the future.
