### PR TITLE
Stop the servers before the stack delete.

### DIFF
--- a/files/reset_openstack_environment.yml
+++ b/files/reset_openstack_environment.yml
@@ -34,7 +34,19 @@
       set_fact:
         openstack: "source {{ openstack_rc }}; {{ openstack_location }}"
 
-    # Get the images.
+    # Get the all the servers by ID.
+    - name: Getting all the servers by ID
+      shell: "{{ openstack }} server list --format value -c ID --limit -1"
+      register: servers
+      changed_when: false
+
+    # Stop all the servers in an attempt to avoid PCI passthrough issues.
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1542494
+    - name: Stopping all the servers
+      shell: "{{ openstack }} server stop {{ item }}"
+      with_items: "{{ servers.stdout_lines }}"
+
+    # Get the heat stacks in this OpenStack environment.
     - name: Getting all the heat stacks
       shell: "{{ openstack }} stack list --format value -c ID"
       register: stacks


### PR DESCRIPTION
This is a seldom used script to deletes all the OpenStack objects in a specific order as to "reset" the OpenStack environment for another OpenShift redeploy. This script is not in the main pipeline and is only used for development purposes to redeploy OpenShift without having to redeploy OpenStack.

On our previous staging cluster Alex did some tests where he deleted 2 VMs manually with PCI devices and they did not go into error state as we thought they would. Afterward I ran the reset script on the staging cluster and checked the VMs. The two servers were in error state at this point. My theory is the script's command `openstack stack delete openshift-cluster` triggered the error in the two VMs that were not stopped.

I want to avoid this problem by stopping all the VMs before running "statck delete" command (because there is no "stack stop" command).

For reference the bugzilla is here:
https://bugzilla.redhat.com/show_bug.cgi?id=1542494