### PR TITLE
First steps of using the provider network.

### DIFF
--- a/roles/openshift_dns/tasks/main.yml
+++ b/roles/openshift_dns/tasks/main.yml
@@ -85,6 +85,10 @@
     cluster_dns_ip: "{{ dns_addresses['stdout'].split(', ')[1] }}"
   failed_when: cluster_dns_ip == ""
 
+# Specify both --dns-nameserver and --no-dns-nameservers to overwrite the current DNS server information.
+- name: Replace the address of the DNS server for the subnet
+  shell: "{{ openstack }} subnet set --no-dns-nameservers --dns-nameserver {{ item }} {{ openstack_subnet_name }}"
+
 # Set the information to update the public DNS records.
 - name: Setting the DNS public update information
   set_fact:

--- a/roles/openshift_on_openstack/templates/all.yml.cfg.j2
+++ b/roles/openshift_on_openstack/templates/all.yml.cfg.j2
@@ -2,7 +2,7 @@
 openshift_openstack_clusterid: "{{ clusterid }}"
 openshift_openstack_public_dns_domain: "{{ dns_domain }}"
 openshift_openstack_keypair_name: "{{ openstack_keypair_name }}"
-openshift_openstack_external_network_name: "{{ openstack_public_network_name }}"
+# openshift_openstack_external_network_name: "{{ openstack_public_network_name }}"
 openshift_openstack_default_image_name: "{{ virtual_image_name }}"
 openshift_openstack_use_vm_load_balancer: true
 openshift_openstack_disable_root: false
@@ -16,9 +16,10 @@ openshift_openstack_cns_flavor: "{{ openshift_cns_flavor }}"
 openshift_openstack_node_flavor: "{{ openshift_node_flavor }}"
 openshift_openstack_lb_flavor: "{{ openshift_lb_flavor }}"
 openshift_openstack_default_flavor: "{{ openshift_default_flavor }}"
-openshift_openstack_subnet_cidr: "192.168.96.0/20"
-openshift_openstack_pool_start: "192.168.96.3"
-openshift_openstack_pool_end: "192.168.111.254"
+openshift_openstack_provider_network_name: "{{ openstack_network_name }}"
+openshift_openstack_subnet_cidr: "{{ openstack_subnet_range }}"
+openshift_openstack_pool_start: "192.168.0.3"
+openshift_openstack_pool_end: "192.168.255.254"
 openshift_openstack_resolve_heat_outputs: False
 openshift_openstack_ephemeral_volumes: true
 openshift_openstack_public_hostname_suffix: '-public'

--- a/vars/openstack.yml
+++ b/vars/openstack.yml
@@ -23,8 +23,8 @@ openstack_server_image: "{{ lookup('env', 'server_image')|default(virtual_image_
 openstack_server_name: "{{ lookup('env', 'server_name')|default('ansible-host', true) }}"
 # The name of the private subnet for the OpenShift install server.
 openstack_subnet_name: "{{ lookup('env', 'subnet_name')|default('ci_subnet', true) }}"
-# The subnet range to use on the OpenStack private subnet (\23 == 510 addresses).
-openstack_subnet_range: "{{ lookup('env', 'subnet_range')|default('192.168.4.0/23', true) }}"
+# The subnet range to use on the OpenStack private subnet (\16 == 65534 addresses).
+openstack_subnet_range: "{{ lookup('env', 'subnet_range')|default('192.168.0.0/16', true) }}"
 # Create flavors in the openstack environment.
 openstack_create_flavors: "{{ lookup('env', 'create_flavors')|default(true, true) }}"
 # Prepare images and upload them to glance in the openstack environment.


### PR DESCRIPTION
This is the first step in using the provider network.

* Start using the `openshift_openstack_provider_network` with the "ci_network" as the name of the network.
* Ensure the "ci_subnet" has a cidr wide enough for our scaling targets.
* The "ci_subnet" should have the cluster DNS configured as the only dns-nameserver. This requires replacing the old DNS value with the cluster DNS value.

I believe this can be deployed in the current "regular" networking environment, would like to test this out on a new deploy sometime soon. 

There will be other changes needed on the OpenShift and OpenStack sides in future PRs where OpenStack will have to change the nic configuration to use the external floating ip VLAN, and we will have to assign the precious few FIPs to the core cluster. Please note I believe we can test all this out without the switch change for the public routable (external) floating ips.