### PR TITLE
Remove the root task as there are no files to patch.

### DIFF
--- a/roles/openshift_ansible_patch/tasks/main.yml
+++ b/roles/openshift_ansible_patch/tasks/main.yml
@@ -6,12 +6,3 @@
     strip: 0
   with_items:
     - "{{ lookup('fileglob', '*.patch').split(',') | sort }}"
-
-- name: Applying patches to files across the filesystem with elevated privileges
-  patch:
-    src: "{{ item }}"
-    basedir: /
-    strip: 0
-  with_items:
-    - "{{ lookup('fileglob', 'root/*.patch').split(',') | sort }}"
-  become: true


### PR DESCRIPTION
```
TASK [openshift_ansible_patch : Applying patches to files across the filesystem with elevated privileges] ***
task path: /home/slave3/workspace/scale-ci_install_OpenShift/roles/openshift_ansible_patch/tasks/main.yml:10
Friday 18 May 2018  10:34:52 -0400 (0:00:02.025)       0:06:37.809 ************ 
 [WARNING]: Unable to find 'root' in expected paths.

fatal: [172.21.0.109]: FAILED! => {"msg": "'list object' has no attribute 'split'"}
```
There is no patches for root anymore, remove this task.