### PR TITLE
Create floating ips for the core cluster.

### DIFF
--- a/roles/openshift_get_core_cluster/tasks/main.yml
+++ b/roles/openshift_get_core_cluster/tasks/main.yml
@@ -28,11 +28,28 @@
   register: networks
   changed_when: false
 
+- name: Create floating ips for each core cluster VM
+  shell: "{{ openstack }} floating ip create {{ openstack_public_network_name }} --format value -c floating_ip_address"
+  register: floating_addresses
+  with_sequence: "{{ networks['stdout_lines']|length }}"
+
+- name: Adding a floating ip address to each core cluster VM
+  # This command can fail with: Instance network is not ready yet (HTTP 400)
+  shell: "{{ openstack }} server add floating ip {{ item[0].split(' ')[0] }} {{ item[1]['stdout'] }}"
+  register: add_result
+  until: add_result['rc'] == 0
+  # Retry 5 times until success.
+  retries: 5
+  delay: 5
+  with_together:
+      - "{{ networks['stdout_lines'] }}"
+      - "{{ floating_addresses['results'] }}"
+
 - name: Creating a list of hosts from the OpenStack networks output
   set_fact:
     ocp_core_cluster: "{{ ocp_core_cluster }} + [{ 'group': '{{ item.0.group }}', 'name': '{{ item.1.split(' ')[0].split('.')[0] }}', 'private_ip': '{{ item.1.split('=')[1].split(', ')[0] }}', 'public_ip': '{{ item.1.split(', ')[1] }}' }]"
   with_subelements:
-    - 
+    -
       - group: masters
         nodes: "{{ networks.stdout_lines | select('match','^master') | list }}"
       - group: infras


### PR DESCRIPTION
The last OpenShift install completed successfully, but the Jenkins job failed with:
```
The task includes an option with an undefined variable. The error was: list object has no element 1
The error appears to have been in '/home/slave3/workspace/scale-ci_install_OpenShift/roles/openshift_get_core_cluster/tasks/main.yml': line 31, column 3
```
referring to:
```yaml
    ocp_core_cluster: "{{ ocp_core_cluster }} + [{ 'group': '{{ item.0.group }}', 'name': '{{ item.1.split(' ')[0].split('.')[0] }}', 'private_ip': '{{ item.1.split('=')[1].split(', ')[0] }}', 'public_ip': '{{ item.1.split(', ')[1] }}' }]"
```
Where there was no public FIP address to parse. This PR addresses this problem by creating a floating ip for each VM in the core cluster.