### PR TITLE
Copy the ca cert to the location where golang looks for

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -61,3 +61,9 @@
     - openstack_etc_hosts
     - jenkins_pipeline
     - openshift_label_nodes
+
+- name: Copy the certs to the location where golang looks for
+  hosts: masters
+  become: yes
+  roles:
+    - openshift_copy_certs

--- a/roles/openshift_copy_certs/tasks/main.yml
+++ b/roles/openshift_copy_certs/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: copy the certs on masters
+  copy:
+    src: /etc/origin/master/ca.crt
+    dest: /etc/ssl/certs/
+    remote_src: true


### PR DESCRIPTION
This commits copies the cert to /etc/ssl/certs on the masters.
This is needed for prometheus-metrics tool to hit the apiserver
and kubelet endpoints.