### PR TITLE
Adding a floating ip role to seperate the get_core_cluster role.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -42,6 +42,7 @@
   vars_files:
     - vars/openstack.yml
   roles:
+    - openstack_add_fips
     - openshift_get_core_cluster
     - openstack_etc_hosts
 

--- a/roles/openshift_get_core_cluster/tasks/main.yml
+++ b/roles/openshift_get_core_cluster/tasks/main.yml
@@ -28,28 +28,6 @@
   register: networks
   changed_when: false
 
-- name: Create floating ips for each core cluster VM
-  shell: "{{ openstack }} floating ip create {{ openstack_public_network_name }} --format value -c floating_ip_address"
-  register: floating_addresses
-  with_sequence: "{{ networks['stdout_lines']|length }}"
-
-- name: Adding a floating ip address to each core cluster VM
-  # This command can fail with: Instance network is not ready yet (HTTP 400)
-  shell: "{{ openstack }} server add floating ip {{ item[0].split(' ')[0] }} {{ item[1]['stdout'] }}"
-  register: add_result
-  until: add_result['rc'] == 0
-  # Retry 5 times until success.
-  retries: 5
-  delay: 5
-  with_together:
-      - "{{ networks['stdout_lines'] }}"
-      - "{{ floating_addresses['results'] }}"
-
-- name: Getting the list of hosts from OpenStack
-  shell: "{{ openstack }} server list --name .*-[0-9]*.{{ clusterid }}.{{ dns_domain }} --format value -c Name -c Networks --limit -1"
-  register: networks
-  changed_when: false
-
 - name: Creating a list of hosts from the OpenStack networks output
   set_fact:
     ocp_core_cluster: "{{ ocp_core_cluster }} + [{ 'group': '{{ item.0.group }}', 'name': '{{ item.1.split(' ')[0].split('.')[0] }}', 'private_ip': '{{ item.1.split('=')[1].split(', ')[0] }}', 'public_ip': '{{ item.1.split(', ')[1] }}' }]"

--- a/roles/openstack_add_fips/tasks/main.yml
+++ b/roles/openstack_add_fips/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+- name: Checking for the OpenStack client
+  stat:
+    path: "{{ openstack_location }}"
+  register: openstack_path
+
+- name: Aborting when the OpenStack client does not exist
+  fail:
+    msg: "The openstack client path '{{ openstack_location }}' is invalid."
+  when: openstack_path.stat.exists == false
+
+- name: Setting openstack variable to source the rc file and contain path to client
+  set_fact:
+    openstack: "source {{ openstack_rc }}; {{ openstack_location }}"
+
+- name: Getting the list of hosts from OpenStack
+  shell: "{{ openstack }} server list --name .*-[0-9]*.{{ clusterid }}.{{ dns_domain }} --format value -c Name -c Networks --limit -1"
+  register: networks
+  changed_when: false
+
+- name: Create floating ips for each core cluster VM
+  shell: "{{ openstack }} floating ip create {{ openstack_public_network_name }} --format value -c floating_ip_address"
+  register: floating_addresses
+  with_sequence: "{{ networks['stdout_lines']|length }}"
+
+- name: Adding a floating ip address to each core cluster VM
+  # This command can fail with: Instance network is not ready yet (HTTP 400)
+  shell: "{{ openstack }} server add floating ip {{ item[0].split(' ')[0] }} {{ item[1]['stdout'] }}"
+  register: add_result
+  until: add_result['rc'] == 0
+  # Retry 5 times until success.
+  retries: 5
+  delay: 5
+  with_together:
+      - "{{ networks['stdout_lines'] }}"
+      - "{{ floating_addresses['results'] }}"

--- a/roles/openstack_add_fips/vars/main.yml
+++ b/roles/openstack_add_fips/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# The path to the OpenStack RC file on the openstack-server, may be named differently than other servers.
+openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/overcloudrc', true) }}"


### PR DESCRIPTION
This makes it easier to run tests of other playbooks that need to get the core cluster in memory.