### PR TITLE
Adding group variable files, and ability to disable service catalog.

### DIFF
--- a/roles/openshift_on_openstack/tasks/main.yml
+++ b/roles/openshift_on_openstack/tasks/main.yml
@@ -88,6 +88,27 @@
   # Note: The copy module does not support recurisve copy of remote sources.
   command: cp -a {{ openshift_openstack_dir }}/sample-inventory/ inventory
 
+# To set variables for different groups, create named files in group_vars.
+- name: Creating new files for app and glusterfs group variables
+  copy:
+    content: "openshift_node_group_name: node-config-compute"
+    dest: "inventory/group_vars/{{ item }}"
+  with_items:
+    - app.yml
+    - glusterfs.yml
+
+# To set variables for infra nodes create infra_hosts.yml in group_vars.
+- name: Creating new file for infra_host group variables
+  copy:
+    content: "openshift_node_group_name: node-config-infra"
+    dest: inventory/group_vars/infra_hosts.yml
+
+# To set variables for master nodes, create a masters.yml file in group_vars.
+- name: Creating new file for masters group variables
+  copy:
+    content: "openshift_node_group_name: node-config-master"
+    dest: inventory/group_vars/masters.yml
+
 # Copy the Ansible configuration file from the openshift-ansible repository.
 - name: Copying the Ansible configuration file from openshift-ansible
   copy:

--- a/roles/openshift_on_openstack/templates/OSEv3.yml.cfg.j2
+++ b/roles/openshift_on_openstack/templates/OSEv3.yml.cfg.j2
@@ -14,6 +14,11 @@ openshift_clock_enabled: true
 # Enable cluster metrics.
 use_cluster_metrics: true
 
+# Enable or disable the service catalog.
+openshift_enable_service_catalog: {{ service_catalog_enable }}
+# Enable template service broker (requires service catalog to be enabled, above)
+template_service_broker_install: {{ template_service_broker_enable }}
+
 # Use the allow all identity provider for conformance tests.
 openshift_master_identity_providers: [{'name': 'allow_all', 'login': 'true', 'challenge': 'true', 'kind': 'AllowAllPasswordIdentityProvider'}]
 

--- a/roles/openshift_on_openstack/vars/main.yml
+++ b/roles/openshift_on_openstack/vars/main.yml
@@ -25,3 +25,7 @@ osev3_yml_path: "{{ ansible_user_dir }}/inventory/group_vars/OSEv3.yml"
 osev3_yml_cfg_path: "{{ ansible_user_dir }}/inventory/group_vars/OSEv3.yml.cfg"
 # Break up the space separate string into a list of image registries for the OSEv3.yml variables.
 registries: "{{ openshift_registries.split(' ') }}"
+# Enable service catalog
+service_catalog_enable: "{{ lookup('env', 'service_catalog_enable')|default(true, true) }}"
+# Enable template service broker (requires service catalog to be enabled)
+template_service_broker_enable: "{{ lookup('env', 'template_service_broker_enable')|default(true, true) }}"


### PR DESCRIPTION
There is a recent change that does sanity checks looking for labels on all OpenShift nodes. This required having a file with the group name mapping to this structure: https://github.com/openshift/openshift-ansible/blob/master/roles/openshift_facts/defaults/main.yml#L120

Also added the ability to disable the service catalog since it is causing such a problem with the current build.