### PR TITLE
Upgrading setuptools before installing Python packages.

### DIFF
--- a/roles/openshift_dependencies/tasks/main.yml
+++ b/roles/openshift_dependencies/tasks/main.yml
@@ -57,6 +57,12 @@
     pip: "{{ virtualenv_directory }}/bin/pip"
   when: virtualenv_directory is defined
 
+# Upgrade setuptools to the latest level before installing modules.
+- name: Upgrade setuptools
+  command: "{{ pip }} install --upgrade setuptools"
+  # Only become root when the virtual environment directory is not defined.
+  become: "{{ virtualenv_directory is not defined }}"
+
 # Install the Python packages using pip with the command module.
 - name: Installing the Python packages
   # Only become root when the virtual environment directory is not defined.


### PR DESCRIPTION
The `python-openstackclient` stopped installing correctly with the error:
```
heat-cfntools 1.2.6 has requirement boto==2.5.2, but you'll have boto 2.45.0 which is incompatible.                                                                                                
heat-cfntools 1.2.6 has requirement pbr<0.6,>=0.5.16, but you'll have pbr 4.0.4 which is incompatible.                                                                                            
heat-cfntools 1.2.6 has requirement psutil<1.0, but you'll have psutil 2.2.1 which is incompatible.                                                                                               
Installing collected packages: requests, six, stevedore, keystoneauth1, Babel, oslo.i18n, netifaces, pyparsing, funcsigs, netaddr, monotonic, wrapt, debtcollector, oslo.utils, contextlib2, pyperc
lip, wcwidth, subprocess32, cmd2, unicodecsv, PyYAML, cliff, ipaddress, requestsexceptions, packaging, deprecation, munch, appdirs, jsonpatch, openstacksdk, simplejson, os-client-config, osc-lib,
 python-cinderclient, msgpack, oslo.serialization, python-novaclient, rfc3986, oslo.config, python-keystoneclient, functools32, jsonschema, warlock, cffi, asn1crypto, cryptography, pyOpenSSL, pyt
hon-glanceclient, python-openstackclient                                                                                                                                                          
  Found existing installation: requests 2.7.0                                                                                                                                                     
Cannot uninstall 'requests'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.    
```
It was determined that setuptools needs to be updated for the python-openstackclient to install correctly.