### PR TITLE
Use 3.10 infra node role as the selector for logging deployments

### DIFF
--- a/roles/openshift_on_openstack/templates/OSEv3.yml.cfg.j2
+++ b/roles/openshift_on_openstack/templates/OSEv3.yml.cfg.j2
@@ -55,9 +55,9 @@ openshift_logging_es_pvc_size: 50Gi
 openshift_logging_es_pvc_storage_class_name: "glusterfs-storage-block"
 openshift_logging_fluentd_read_from_head: false
 openshift_logging_use_mux: false
-openshift_logging_curator_nodeselector: {"region": "infra"}
-openshift_logging_kibana_nodeselector: {"region": "infra"}
-openshift_logging_es_nodeselector: {"region": "infra"}
+openshift_logging_curator_nodeselector: {"node-role.kubernetes.io/infra" : "true"}
+openshift_logging_kibana_nodeselector: {"node-role.kubernetes.io/infra" : "true"}
+openshift_logging_es_nodeselector: {"node-role.kubernetes.io/infra" : "true"}
 
 # Disable cockpit.
 osm_use_cockpit: false


### PR DESCRIPTION
Use the 3.10 node role labels as logging selector.  No longer rely on custom labels.

@mbruzek Please review