### PR TITLE
Proactively adding openshift_node_group_name on new nodes for scaleup.

### DIFF
--- a/roles/openshift_on_openstack_scale/tasks/scaleup.yml
+++ b/roles/openshift_on_openstack_scale/tasks/scaleup.yml
@@ -60,7 +60,7 @@
 - name: Adding the addresses to the new nodes inventory file
   lineinfile:
     path: "{{ new_nodes_inventory }}"
-    line: "{{ item['private_ip'] }} openshift_node_labels=\"{'region': 'primary'}\""
+    line: "{{ item['private_ip'] }} openshift_node_group_name=\"node-config-compute\""
   with_items: "{{ hosts_new }}"
 
 # Add the new nodes to DNS.


### PR DESCRIPTION
In 3.10 the node labels are controlled by the `openshift_node_group_name` variable. Need to set this for the scale-up operation so the new-nodes are labeled correctly.

Related to https://github.com/redhat-performance/scale-ci-ansible/pull/148