### PR TITLE
Adding Pbench web server role to preview test results.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -62,6 +62,7 @@
     - openstack_etc_hosts
     - jenkins_pipeline
     - openshift_label_nodes
+    - pbench_web_server
 
 - name: Copy the certs to the location where golang looks for
   hosts: masters

--- a/roles/pbench_web_server/tasks/main.yml
+++ b/roles/pbench_web_server/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+- name: Install Apache httpd server and pbench-web-server packages.
+  yum:
+    name: "{{ packages }}"
+  vars:
+    packages:
+    - httpd
+    - pbench-web-server
+  become: true
+
+- name: Set the httpd port to listen on.
+  lineinfile:
+    dest: "{{ httpd_conf }}"
+    state: present
+    regexp: '^\s*Listen\s*.*$'
+    line: "Listen {{ httpd_port }}"
+    backup: false
+  become: true
+
+- name: Do not restrict item name width in directory listing.
+  lineinfile:
+    dest: "{{ httpd_autoindex_conf }}"
+    state: present
+    regexp: '^(\s*IndexOptions.*)$'
+    line: '\1 NameWidth=*'
+    backup: false
+    backrefs: true
+  become: true
+
+- name: Start and enable Apache httpd server.
+  systemd:
+    name: httpd
+    enabled: yes
+    state: started
+  become: true
+
+- name: Ensure pbench-web-server static content is visible by the Apache web server.
+  file:
+    path: "{{ httpd_htdocs_dir }}/static"
+    src: "{{ pbench_web_server_static_dir }}"
+    state: link
+  become: true
+
+- name: Ensure {{ pbench_agent_dir }} is served by the Apache web server.
+  file:
+    dest: "{{ httpd_htdocs_dir }}/pbench-agent"
+    src: "{{ pbench_agent_dir }}"
+    state: link
+  become: true
+
+- name: Add an SELinux context for {{ pbench_agent_dir }}.
+  lineinfile:
+    dest: "{{ selinux_file_contexts }}"
+    state: present
+    regexp: '^{{ pbench_agent_dir }}.*$'
+    line: "{{ pbench_agent_dir }}(/.*)?     system_u:object_r:httpd_sys_content_t:s0"
+    backup: false
+    backrefs: true
+  become: true
+
+- name: Restore SELinux contexts on {{ pbench_agent_dir }}, so that it can be read by a web server.
+  command: "restorecon -RF {{ pbench_agent_dir }}"
+  become: true

--- a/roles/pbench_web_server/vars/main.yml
+++ b/roles/pbench_web_server/vars/main.yml
@@ -1,0 +1,15 @@
+---
+# Web server document root directory.
+httpd_htdocs_dir: '/var/www/html'
+# Web server port to listen on.
+httpd_port: 80
+# Apache web server configuration file.
+httpd_conf: '/etc/httpd/conf/httpd.conf'
+# Apache web server autoindex configuration file.
+httpd_autoindex_conf: '/etc/httpd/conf.d/autoindex.conf'
+# Pbench agent default directory.
+pbench_agent_dir: '/var/lib/pbench-agent'
+# Pbench web server directory with static content.
+pbench_web_server_static_dir: '/opt/pbench-web-server/html/static'
+# SELinux file contexts file.
+selinux_file_contexts: '/etc/selinux/targeted/contexts/files/file_contexts'


### PR DESCRIPTION
Adds a possibility to preview test results before sending them off to a Pbench
server for permanent storage.  This will shorten the iterations on new tests
(prototypes) which are not automated and save space on backend Pbench servers.