### PR TITLE
Limit the query to ACTIVE servers before shutting them off.

### DIFF
--- a/files/reset_openstack_environment.yml
+++ b/files/reset_openstack_environment.yml
@@ -35,8 +35,8 @@
         openstack: "source {{ openstack_rc }}; {{ openstack_location }}"
 
     # Get the all the servers by ID.
-    - name: Getting all the servers by ID
-      shell: "{{ openstack }} server list --format value -c ID --limit -1"
+    - name: Getting all the ACTIVE servers by ID
+      shell: "{{ openstack }} server list --format value -c ID --limit -1 --status ACTIVE"
       register: servers
       changed_when: false
 


### PR DESCRIPTION
The reset script gets an error on stopping servers that are in BUILD state (broken).

Fixes #158 