### PR TITLE
Adding blocks to dns creation and scaleup subprocesses.

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -11,6 +11,8 @@ clusterid: "{{ lookup('env', 'clusterid')|default('scale-ci', true) }}"
 dns_domain: "{{ lookup('env', 'dns_domain')|default('example.com', true) }}"
 # The remote directory to store any scale-ci files.
 install_directory: "{{ ansible_user_dir }}/{{ clusterid }}"
+# The remote directory to store the scale-ci log files.
+log_directory: "{{ ansible_user_dir }}/logs"
 # The version of OpenShift Container Platform to install and test.
 ocp_major_minor: "{{ lookup('env', 'ocp_major_minor')|default('3.10', true) }}"
 # The properties file contains the keys and values for the next job.

--- a/roles/openshift_dependencies/tasks/main.yml
+++ b/roles/openshift_dependencies/tasks/main.yml
@@ -127,3 +127,9 @@
   copy:
     src: "{{ playbook_dir }}/openstackrc"
     dest: "{{ openstack_rc }}"
+
+# Create the log directory on the target host
+- name: Create the log directory on the target host
+  file:
+    path: "{{ log_directory }}"
+    state: directory

--- a/roles/openshift_dns/tasks/main.yml
+++ b/roles/openshift_dns/tasks/main.yml
@@ -58,14 +58,22 @@
 # Set the path for the DNS install log file.
 - name: Creating the DNS install log file variable
   set_fact:
-    dns_install_log: "{{ ansible_user_dir }}/dns_install.log"
+    dns_install_log: "{{ log_directory }}/dns_install.log"
 
-# Run the Ansible playbook that creates the DNS server.
-- name: Creating the DNS server
-  shell: "{{ ansible_playbook }} -vvv --key-file {{ ansible_user_dir }}/.ssh/id_rsa -e @dns_vars.yml openshift-ansible-contrib/reference-architecture/osp-dns/deploy-dns.yaml 2>&1 > {{ dns_install_log }}"
-  args:
-    # Use bash to get the posix style redirects.
-    executable: /bin/bash
+- block:
+    # Run the Ansible playbook that creates the DNS server.
+    - name: Creating the DNS server
+      shell: "{{ ansible_playbook }} -vvv --key-file {{ ansible_user_dir }}/.ssh/id_rsa -e @dns_vars.yml openshift-ansible-contrib/reference-architecture/osp-dns/deploy-dns.yaml 2>&1 > {{ dns_install_log }}"
+      args:
+        # Use bash to get the posix style redirects.
+        executable: /bin/bash
+  always:
+    - name: Copy the log file to the artifacts directory
+      synchronize:
+        src: "{{ dns_install_log }}"
+        dest: "{{ artifacts_directory }}"
+        mode: pull
+        use_ssh_args: yes
 
 # The openstack variable includes the rc file and the path to the OpenStack client.
 - name: Setting the openstack variable to source the rc file and contain path to client

--- a/roles/openshift_on_openstack/tasks/main.yml
+++ b/roles/openshift_on_openstack/tasks/main.yml
@@ -211,7 +211,7 @@
 # Set the path for the prerequisite log file.
 - name: Creating a variable for the prerequisite log file
   set_fact:
-    prerequisite_log: "{{ ansible_user_dir }}/openshift_prerequisites.log"
+    prerequisite_log: "{{ log_directory }}/openshift_prerequisites.log"
 
 - name: OpenShift prerequisite block
   block:
@@ -252,7 +252,7 @@
 # Set the path for the OpenStack provision log file.
 - name: Creating a variable for the OpenStack provision log file
   set_fact:
-    openstack_provision_log: "{{ ansible_user_dir }}/openstack_provision.log"
+    openstack_provision_log: "{{ log_directory }}/openstack_provision.log"
 
 - name: OpenStack provision block
   block:
@@ -286,7 +286,7 @@
 # Set the path for the time servers log file.
 - name: Creating a variable for the time servers log file
   set_fact:
-    time_servers_log: "{{ ansible_user_dir }}/time_servers.log"
+    time_servers_log: "{{ log_directory }}/time_servers.log"
 
 - name: Configure time servers block
   block:
@@ -313,7 +313,7 @@
 # Set the path for the block devices log file.
 - name: Creating a variable for the the block devices log file
   set_fact:
-    block_devices_log: "{{ ansible_user_dir }}/block_devices.log"
+    block_devices_log: "{{ log_directory }}/block_devices.log"
 
 - name: Configure block devices
   block:
@@ -334,7 +334,7 @@
 # Set the path for the OpenShift install log file.
 - name: Creating the OpenShift install log file variable
   set_fact:
-    openshift_install_log: "{{ ansible_user_dir }}/openshift_install.log"
+    openshift_install_log: "{{ log_directory }}/openshift_install.log"
 
 - name: Install OpenShift block
   block:

--- a/roles/openshift_on_openstack_scale/tasks/scaleup.yml
+++ b/roles/openshift_on_openstack_scale/tasks/scaleup.yml
@@ -14,17 +14,30 @@
   with_items:
     - { find: "^#?openshift_openstack_num_nodes.*", replace: "openshift_openstack_num_nodes: {{ block['end']|int + 1 }}" }
 
-# Run the Ansible playbook that creates the OpenStack resources.
-- name: Creating the OpenStack resources
-  shell: >
-    {{ ansible_playbook }} -vv
-    --user openshift
-    -i inventory
-    -i {{ inventory_py }}
-    {{ openshift_cluster_directory }}/provision_resources.yml 2>&1 >> openstack_provision_resources_{{ block['end'] }}.log
-  args:
-    # Use bash to get the posix style redirects.
-    executable: /bin/bash
+# Set the path for the OpenShift provision log file.
+- name: Creating the OpenShift provision log file variable
+  set_fact:
+    scaleup_provision_log: "{{ log_directory }}/scaleup_provision_resources_{{ block['end'] }}.log"
+
+- block:
+    # Run the Ansible playbook that creates the OpenStack resources.
+    - name: Creating the OpenStack resources
+      shell: >
+        {{ ansible_playbook }} -vv
+        --user openshift
+        -i inventory
+        -i {{ inventory_py }}
+        {{ openshift_cluster_directory }}/provision_resources.yml 2>&1 >> {{ scaleup_provision_log }}
+      args:
+        # Use bash to get the posix style redirects.
+        executable: /bin/bash
+  always:
+    - name: Copy the log file to the artifacts directory
+      synchronize:
+        src: "{{ scaleup_provision_log }}"
+        dest: "{{ artifacts_directory }}"
+        mode: pull
+        use_ssh_args: yes
 
 # Get the post scale up OpenStack VMs by name.
 - name: Getting the post scale up list of app-nodes
@@ -91,26 +104,52 @@
     timeout: 120
   with_items: "{{ hosts_new }}"
 
-# Configure the time servers on all the new nodes.
-- name: Configuring the time servers on the new nodes
-  shell: >
-    {{ ansible_playbook }} -vv
-    --user openshift
-    -i {{ new_nodes_inventory }}
-    configure_time_servers.yml 2>&1 >> time_servers_{{ block['end'] }}.log
-  args:
-    # Use bash to get the posix style redirects.
-    executable: /bin/bash
+# Set the path for the time servers log file.
+- name: Creating the time servers log variable
+  set_fact:
+    scaleup_time_servers_log: "{{ log_directory }}/scaleup_time_servers_{{ block['end'] }}.log"
 
-# Scale up the OpenShift cluster.
-- name: Scaling up the OpenShift resources
-  shell: >
-    {{ ansible_playbook_scaleup }} -vv
-    --user openshift
-    -i inventory/
-    -i {{ inventory_py }}
-    -i {{ new_nodes_inventory }}
-    {{ openshift_node_directory }}/scaleup.yml 2>&1 >> openshift_scaleup_{{ block['end'] }}.log
-  args:
-    # Use bash to get the posix style redirects.
-    executable: /bin/bash
+- block:
+    # Configure the time servers on all the new nodes.
+    - name: Configuring the time servers on the new nodes
+      shell: >
+        {{ ansible_playbook }} -vv
+        --user openshift
+        -i {{ new_nodes_inventory }}
+        configure_time_servers.yml 2>&1 >> {{ scaleup_time_servers_log }}
+      args:
+        # Use bash to get the posix style redirects.
+        executable: /bin/bash
+  always:
+    - name: Copy the log file to the artifacts directory
+      synchronize:
+        src: "{{ scaleup_time_servers_log }}"
+        dest: "{{ artifacts_directory }}"
+        mode: pull
+        use_ssh_args: yes
+
+# Set the path for the OpenShift scaleup log file.
+- name: Creating the time servers log variable
+  set_fact:
+    scaleup_openshift_log: "{{ log_directory }}/scaleup_openshift_{{ block['end'] }}.log"
+
+- block:
+    # Scale up the OpenShift cluster.
+    - name: Scaling up the OpenShift resources
+      shell: >
+        {{ ansible_playbook_scaleup }} -vv
+        --user openshift
+        -i inventory/
+        -i {{ inventory_py }}
+        -i {{ new_nodes_inventory }}
+        {{ openshift_node_directory }}/scaleup.yml 2>&1 >> {{ scaleup_openshift_log }}
+      args:
+        # Use bash to get the posix style redirects.
+        executable: /bin/bash
+  always:
+    - name: Copy the log file to the artifacts directory
+      synchronize:
+        src: "{{ scaleup_time_servers_log }}"
+        dest: "{{ artifacts_directory }}"
+        mode: pull
+        use_ssh_args: yes


### PR DESCRIPTION
Fixes #160 

Also adding a logs directory should help clean up cloud-user's home directory on ansible-host.

Fixes #119 

In addition while doing this I noticed that there were several subprocess log files that were not captured specifically in the scaleup work.
