### PR TITLE
Create the artifacts directory sooner so to capture all log files.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -1,8 +1,14 @@
 ---
 - name: Find and prepare the virtual machine images
+  hosts: image-server
   vars_files:
     - vars/openstack.yml
-  hosts: image-server
+  pre-tasks:
+    - name: Ensure the local artifacts directory exists
+      file:
+        path: "{{ artifacts_directory }}"
+        state: directory
+      delegate_to: localhost
   roles:
     - { role: image_preparation, when: openstack_upload_images | default(True) | bool }
 

--- a/roles/openshift_on_openstack/tasks/main.yml
+++ b/roles/openshift_on_openstack/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-- name: Ensure the local artifacts directory exists
-  file:
-    path: "{{ artifacts_directory }}"
-    state: directory
-  delegate_to: localhost
-
 # Remove all old directories and files.
 - name: Removing any old directories or files from previous attempts
   file:

--- a/scaleup.yml
+++ b/scaleup.yml
@@ -3,6 +3,12 @@
   hosts: openstack-server
   vars_files:
     - vars/openstack.yml
+  pre-tasks:
+    - name: Ensure the local artifacts directory exists
+      file:
+        path: "{{ artifacts_directory }}"
+        state: directory
+      delegate_to: localhost
   roles:
     - openstack_get_server
 


### PR DESCRIPTION
Encountered an error when trying to rsync the dns logs:
```
rsync: change_dir#3 \"/home/slave3/workspace/scale-ci_install_OpenShift/artifacts\" failed: No such file or directory (2)
rsync error: errors selecting input/output files
```
Addressing that issue.