### PR TITLE
3.11 requires Ansible version 2.6 or later.

### DIFF
--- a/roles/openshift_dependencies/vars/main.yml
+++ b/roles/openshift_dependencies/vars/main.yml
@@ -1,4 +1,6 @@
 ---
+# The version of ansible to install on the target server.
+ansible_version: "{{ lookup('env', 'ansible_version')|default('2.6', true) }}"
 # The path to the OpenStack RC file on the server vm, may be named differently than other servers.
 openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/keystonerc', true) }}"
 # The boolean to control the cleaning of the yum cache.
@@ -26,7 +28,7 @@ packages:
     - python-devel
     - python-virtualenv
   python:
-    - ansible==2.4.3
+    - "ansible=={{ ansible_version }}""
     - dnspython==1.15.0
     - Jinja2==2.10
     - jmespath==0.9.3


### PR DESCRIPTION
Correcting error in prerequisites:
```
FATAL: Current Ansible version (2.4.3.0) is not supported. Supported versions: 2.6.0 or newer
```