### PR TITLE
OpenShift 3.10 requires Ansible verison 2.4.3.

### DIFF
--- a/roles/openshift_dependencies/vars/main.yml
+++ b/roles/openshift_dependencies/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # The version of ansible to install on the target server.
-ansible_required_version: "{{ lookup('env', 'ansible_required_version')|default('2.6', true) }}"
+ansible_required_version: "{{ lookup('env', 'ansible_required_version')|default('2.4.3', true) }}"
 # The boolean to control the cleaning of the yum cache.
 clean_yum_cache: "{{ lookup('env', 'clean_yum_cache')|default(false, true) }}"
 # The path to the OpenStack RC file on the server vm, may be named differently than other servers.


### PR DESCRIPTION
I updated the version of Ansible before creating the release-3.10 branch.

Getting the 2.4.3 version back to the release-3.10 branch.