### PR TITLE
Trim whitespace from variables that split on whitespace

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -14,11 +14,11 @@ install_directory: "{{ ansible_user_dir }}/{{ clusterid }}"
 # The remote directory to store the scale-ci log files.
 log_directory: "{{ ansible_user_dir }}/logs"
 # The version of OpenShift Container Platform to install and test.
-ocp_major_minor: "{{ lookup('env', 'ocp_major_minor')|default('3.10', true) }}"
+ocp_major_minor: "{{ lookup('env', 'ocp_major_minor')|default('3.11', true) }}"
 # The properties file contains the keys and values for the next job.
 properties_file: "{{ lookup('env', 'properties_file')|default('./next.properties', true) }}"
 # Look up the environment variable with a space separated string of time servers.
-time_servers: "{{ lookup('env', 'time_servers')|default('0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org', true) }}"
+time_servers: "{{ lookup('env', 'time_servers')|default('0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org', true)|trim }}"
 # Break up the space separated string into a list of time servers.
 time_servers_list: "{{ time_servers.split(' ') }}"
 # The virtual image name to use in OpenStack when creating virtual servers.

--- a/roles/openshift_on_openstack/vars/main.yml
+++ b/roles/openshift_on_openstack/vars/main.yml
@@ -16,7 +16,7 @@ nsupdate_file: "{{ lookup('env', 'nsupdate_file')|default(ansible_user_dir ~ '/n
 # Clone openshift-ansible repository rather than copying /root/openshift-ansible
 openshift_ansible_clone: "{{ lookup('env', 'openshift_ansible_clone')|default(false, true) }}"
 # Look up the environment variable with a space separated string of image registry servers to add to the container configuration.
-openshift_registries: "{{ lookup('env', 'openshift_registries') }}"
+openshift_registries: "{{ lookup('env', 'openshift_registries')|trim }}"
 # The path to the OpenStack RC file on the server vm, may be named differently than other servers.
 openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/keystonerc', true) }}"
 # The path to the OSEv3.yml file on the target-server.


### PR DESCRIPTION
We had a properties file with extra whitespace at the end of the value. This created an array with several empty array values. Use the Jina trim filter for these variables.