### PR TITLE
The masters group changed to openstack_master_nodes.

### DIFF
--- a/roles/openshift_on_openstack/templates/prepare_block_devices.yml
+++ b/roles/openshift_on_openstack/templates/prepare_block_devices.yml
@@ -1,6 +1,6 @@
 ---
 - name: A playbook to prepare and mount block devices
-  hosts: masters
+  hosts: openstack_master_nodes
   become: true
   vars:
     device_path: "{{ block_device|default('/dev/nvme0n1') }}"


### PR DESCRIPTION
Resolving: 
```
[WARNING]: Could not match supplied host pattern, ignoring: masters"
```
for the task `TASK [openshift_on_openstack : Configuring the block devices on the master nodes] ***`

The PR https://github.com/openshift/openshift-ansible/pull/9243 changed the default group names when `inventory.py` is run.