### PR TITLE
Do not call the patch task any longer. Nothing to patch.

### DIFF
--- a/roles/openshift_on_openstack/tasks/main.yml
+++ b/roles/openshift_on_openstack/tasks/main.yml
@@ -62,11 +62,6 @@
     version: "{{ openshift_ansible_version }}"
   when: openshift_ansible_clone | bool
 
-# Include the tasks from the openshift_ansible_patch role.
-- name: Include the tasks to patch files in the openshift-ansible directory
-  include_role:
-    name: openshift_ansible_patch
-
 # Set the openshift-ansible openstack path.
 - name: Creating the openshift_openstack directory variable
   set_fact:


### PR DESCRIPTION
Got an error trying to patch with an empty list:  
```
TASK [openshift_ansible_patch : Applying patches to files in /home/cloud-user directory] ***
task path: /home/slave5/workspace/scale-ci_install_OpenShift/roles/openshift_ansible_patch/tasks/main.yml:2
Saturday 11 August 2018  03:57:01 +0800 (0:00:00.033)       0:06:34.560 ******* 
fatal: [10.12.80.23]: FAILED! => {"failed": true, "msg": "'list object' has no attribute 'split'"}
```