### PR TITLE
Adding a patch to wipe glusterfs before a deploy.

### DIFF
--- a/roles/openshift_ansible_patch/files/40-glusterfs_wipefs.patch
+++ b/roles/openshift_ansible_patch/files/40-glusterfs_wipefs.patch
@@ -1,0 +1,16 @@
+--- openshift-ansible.orig/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
++++ openshift-ansible/roles/openshift_storage_glusterfs/tasks/glusterfs_deploy.yml
+@@ -3,6 +3,13 @@
+     that: "glusterfs_nodes | count >= 3"
+     msg: There must be at least three GlusterFS nodes specified
+
++- name: Wipe filesystem signatures from storage devices
++  command: "wipefs -a {% for device in hostvars[item].glusterfs_devices %}{{ device }} {% endfor %}"
++  delegate_to: "{{ item }}"
++  with_items: "{{ glusterfs_nodes | default([]) }}"
++  failed_when: False
++  when: glusterfs_wipe
++
+ - name: Copy GlusterFS DaemonSet template
+   copy:
+     src: "glusterfs-template.yml"

--- a/roles/openshift_on_openstack/tasks/main.yml
+++ b/roles/openshift_on_openstack/tasks/main.yml
@@ -62,6 +62,11 @@
     version: "{{ openshift_ansible_version }}"
   when: openshift_ansible_clone | bool
 
+# Include the tasks from the openshift_ansible_patch role.
+- name: Include the tasks to patch files in the openshift-ansible directory
+  include_role:
+    name: openshift_ansible_patch
+
 # Set the openshift-ansible openstack path.
 - name: Creating the openshift_openstack directory variable
   set_fact:


### PR DESCRIPTION
The old glusterfs patch did not apply cleanly and was removed in #175.

We still need to wipe the filesystem before deploying again.

Created a new patch and adding the patch process back into the main flow.