### PR TITLE
Setting a variable to pull the image from a different registry.

### DIFF
--- a/roles/openshift_on_openstack/templates/OSEv3.yml.cfg.j2
+++ b/roles/openshift_on_openstack/templates/OSEv3.yml.cfg.j2
@@ -46,6 +46,7 @@ openshift_storage_glusterfs_wipe: true
 # Cluster Monitoring Operator
 openshift_monitoring_deploy: true
 openshift_cluster_monitoring_operator_install: true
+l_openshift_cluster_monitoring_operator_ocp_image_registry: "registry.reg-aws.openshift.com:443/openshift3/"
 
 # EFK logging stack variables
 openshift_logging_install_logging: true


### PR DESCRIPTION
This is a temporary work around for the image registry of the cluster-monitoring-operator being bad.