### PR TITLE
Calling the new scaleup playbook for 3.11.

### DIFF
--- a/roles/openshift_on_openstack_scale/tasks/scaleup.yml
+++ b/roles/openshift_on_openstack_scale/tasks/scaleup.yml
@@ -167,7 +167,7 @@
         -i inventory/
         -i {{ inventory_py }}
         -i {{ new_nodes_inventory }}
-        {{ openshift_node_directory }}/scaleup.yml 2>&1 >> {{ scaleup_openshift_log }}
+        {{ openshift_cluster_directory }}/node-scaleup.yml 2>&1 >> {{ scaleup_openshift_log }}
       args:
         # Use bash to get the posix style redirects.
         executable: /bin/bash

--- a/roles/openshift_on_openstack_scale/vars/main.yml
+++ b/roles/openshift_on_openstack_scale/vars/main.yml
@@ -13,7 +13,5 @@ dns_key_name: "{{ lookup('env', 'dns_key_name')|default('update-key', true) }}"
 inventory_py: "{{ ansible_user_dir }}/openshift-ansible/playbooks/openstack/inventory.py"
 # The path to the openshift-ansible openshift-cluster directory.
 openshift_cluster_directory: "{{ ansible_user_dir }}/openshift-ansible/playbooks/openstack/openshift-cluster"
-# The path to the openshift-ansible openshift-node directory.
-openshift_node_directory: "{{ ansible_user_dir }}/openshift-ansible/playbooks/openshift-node"
 # The path to the OpenStack RC file on the server vm, may be named differently than other servers.
 openstack_rc: "{{ lookup('env', 'openstack_rc_path')|default(ansible_user_dir ~ '/keystonerc', true) }}"


### PR DESCRIPTION
The 3.11 has documented a new scale up procedure for nodes [here](https://github.com/openshift/openshift-ansible/blob/master/playbooks/openstack/configuration.md#2-scale-the-cluster). It is a different playbook to perform the scaleup procedure in 3.11.

If we are no longer calling the old playbook, the variable `openshift_node_directory` is no longer needed.