### PR TITLE
Using the new inventory for scaleup, and the old group name.

### DIFF
--- a/roles/openshift_on_openstack/templates/prepare_block_devices.yml
+++ b/roles/openshift_on_openstack/templates/prepare_block_devices.yml
@@ -1,6 +1,6 @@
 ---
 - name: A playbook to prepare and mount block devices
-  hosts: openstack_master_nodes
+  hosts: masters
   become: true
   vars:
     device_path: "{{ block_device|default('/dev/nvme0n1') }}"

--- a/roles/openshift_on_openstack_scale/tasks/scaleup.yml
+++ b/roles/openshift_on_openstack_scale/tasks/scaleup.yml
@@ -153,6 +153,11 @@
         mode: pull
         use_ssh_args: yes
 
+# Set the path to the scaleup_inventory.py file.
+- name: Creating the scaleup_inventory.py variable
+  set_fact:
+    scaleup_inventory_py: "{{ ansible_user_dir }}/openshift-ansible/playbooks/openstack/scaleup_inventory.py"
+
 # Set the path for the OpenShift scaleup log file.
 - name: Creating the OpenShift scaleup log variable
   set_fact:
@@ -165,7 +170,7 @@
         {{ ansible_playbook_scaleup }} -vv
         --user openshift
         -i inventory/
-        -i {{ inventory_py }}
+        -i {{ scaleup_inventory_py }}
         -i {{ new_nodes_inventory }}
         {{ openshift_cluster_directory }}/node-scaleup.yml 2>&1 >> {{ scaleup_openshift_log }}
       args:


### PR DESCRIPTION
This is the work that needs to be done when upstream lands https://github.com/openshift/openshift-ansible/pull/9496 when they change the `inventory.py` file and introduce `scaleup_inventory.py`

Do not merge until the above PR has landed in openshift-ansible.