### PR TITLE
The new inventory has eliminated the app group and the count was off.

### DIFF
--- a/roles/openshift_on_openstack_scale/tasks/main.yml
+++ b/roles/openshift_on_openstack_scale/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Run the dynamic inventory to get the current app hosts.
 - name: Running the dynamic inventory file to get the current app hosts
-  shell: ". {{ openstack_rc }}; python {{ inventory_py }} | jq '.app.hosts|length'"
+  shell: ". {{ openstack_rc }}; {{ inventory_py }} --list | jq '.openstack_compute_nodes["hosts"] | length'"
   register: output
   changed_when: false
 


### PR DESCRIPTION
The app group was eliminated from the recent `inventory.py` updates causing our starting app node count to always be zero. This causes problems with the scaleup as the automation can not know how many nodes to start with.
