### PR TITLE
Add additional label to worker nodes post scale up

### DIFF
--- a/rhcos-scale.yml
+++ b/rhcos-scale.yml
@@ -44,3 +44,7 @@
       until: scaled_worker_node_count.stdout|int == rhcos_worker_count|int
       delay: 1
       retries: "{{poll_attempts|int}}"
+
+    - name: Add additional label to worker nodes to provide ablity to isolate workloads on workers
+      shell: |
+        oc label nodes --overwrite -l 'node-role.kubernetes.io/worker=' computenode=true


### PR DESCRIPTION
The label will be used with mastervertical tests to assign workloads only on
worker nodes.  This will help prevent non-infra workloads from running on
infra nodes.