### PR TITLE
Add support to use the install binary from the payload

### DIFF
--- a/OCP-4.X/inventory.example
+++ b/OCP-4.X/inventory.example
@@ -33,8 +33,14 @@ OPENSHIFT_INSTALL_HOST_PREFIX=23
 OPENSHIFT_INSTALL_VPC_CIDR_BLOCK=
 OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=
 OPENSHIFT_INSTALL_LOG_DIR=/root/ocp
+## set this to build OpenShift installer from the github releases
+OPENSHIFT_INSTALL_USE_GIT_INSTALLER=False
 OPENSHIFT_INSTALL_INSTALLER_VERSION=v0.16.1
-### change this to v1beta1 when using installer version <= v0.11.0, also check the apiversion installer is using before setting this var
+## The following vars are needed to extract openshift-installer binary from the payload
+OPENSHIFT_INSTALL_QUAY_REGISTRY_TOKEN=
+OPENSHIFT_INSTALL_IMAGE_REGISTRY=
+OPENSHIFT_INSTALL_REGISTRY_TOKEN=
+## change this to v1beta1 when using installer version <= v0.11.0, also check the apiversion installer is using before setting this var
 OPENSHIFT_INSTALL_APIVERSION=v1beta4
 
 # Ansible vars

--- a/OCP-4.X/roles/install/tasks/main.yml
+++ b/OCP-4.X/roles/install/tasks/main.yml
@@ -20,26 +20,6 @@
     path: "{{ GOPATH | default('/root/.go') }}"
     state: directory
 
-- name: set workdir
-  set_fact:
-    workdir: "{{ GOPATH }}/src/github.com/openshift/installer"
-
-- name: cleanup installer code if it exists
-  file:
-    path: "{{ workdir }}"
-    state: absent
-
-- name: cleanup vars file
-  file:
-    path: /tmp/ocp-env.sh
-    state: absent
-
-- name: get the installer bits
-  git:
-    repo: 'https://github.com/openshift/installer.git'
-    dest: "{{ workdir }}"
-    version: "{{ OPENSHIFT_INSTALL_INSTALLER_VERSION }}"
-
 - name: create .aws dir
   file:
     path: "{{ ansible_env.HOME }}/.aws"
@@ -55,33 +35,43 @@
      src: credentials.j2
      dest: "{{ ansible_env.HOME }}/.aws/credentials"
 
-- name: build installer binary
-  shell: cd {{ workdir }}; hack/build.sh
-  environment:
-     GOPATH: "{{ GOPATH }}"
+- name: set workdir
+  set_fact:
+    workdir: "{{ GOPATH }}/src/github.com/openshift/installer"
 
-- name: setup install-config
-  template:
-     src: install-config.yaml.j2
-     dest: "{{ workdir }}/install-config.yaml"
+- block:
+    - name: cleanup installer code if it exists
+      file:
+        path: "{{ workdir }}"
+        state: absent
+ 
+    - name: get the installer bits
+      git:
+        repo: 'https://github.com/openshift/installer.git'
+        dest: "{{ workdir }}"
+        version: "{{ OPENSHIFT_INSTALL_INSTALLER_VERSION }}"
 
-- name: ignition configs
-  shell: "cd {{ workdir }}; OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE }} _OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE }} bin/openshift-install create ignition-configs"
-  when: (OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE is defined) and (OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE != "")
+    - name: build installer binary
+      shell: cd {{ workdir }}; hack/build.sh
+      environment:
+        GOPATH: "{{ GOPATH }}"
+  when: OPENSHIFT_INSTALL_USE_GIT_INSTALLER | default(False)
 
-- name: ignition configs
-  shell: "cd {{ workdir }}; bin/openshift-install create ignition-configs"
-  when: (OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE is undefined) or (OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE == "")
+- block:
+    - name: create workdir
+      file:
+        path: "{{ workdir }}/bin"
+        state: directory
 
-- name: set the user in ignition configs
-  replace:
-    path: "{{ item }}"
-    regexp: "core"
-    replace: "{{ OPENSHIFT_INSTALL_USER }}"
-  with_items:
-     - "{{ workdir }}/bootstrap.ign"
-     - "{{ workdir }}/master.ign"
-     - "{{ workdir }}/worker.ign"
+    - name: setup config to talk to registry
+      template:
+        src: registry_auth.j2
+        dest: "{{ workdir }}/bin/config.json"
+
+    - name: extract openshift-install binary from the payload
+      #shell: "cd {{ workdir }}/bin; oc image extract {{ OPENSHIFT_INSTALL_BINARY_IMAGE }} --file=/usr/bin/openshift-install; chmod +x openshift-install"
+      shell: "cd {{ workdir }}/bin; oc adm release extract --tools {{ OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE }}; ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'; chmod +x openshift-install"
+  when: not OPENSHIFT_INSTALL_USE_GIT_INSTALLER | default(False)
 
 - name: create openshift install log dir
   file:
@@ -104,6 +94,28 @@
   when: OPENSHIFT_INSTALL_PLATFORM == "libvirt"
 
 - block:
+    - name: setup install-config
+      template:
+        src: install-config.yaml.j2
+        dest: "{{ workdir }}/install-config.yaml" 
+    - name: ignition configs
+      shell: "cd {{ workdir }}; OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE }} _OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE }} bin/openshift-install create ignition-configs"
+      when: (OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE is defined) and (OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE != "")
+
+    - name: ignition configs
+      shell: "cd {{ workdir }}; bin/openshift-install create ignition-configs"
+      when: (OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE is undefined) or (OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE == "")
+
+    - name: set the user in ignition configs
+      replace:
+        path: "{{ item }}"
+        regexp: "core"
+        replace: "{{ OPENSHIFT_INSTALL_USER }}"
+      with_items:
+        - "{{ workdir }}/bootstrap.ign"
+        - "{{ workdir }}/master.ign"
+        - "{{ workdir }}/worker.ign"
+
     - name: run openshift installer on aws using the image override
       shell: |
         set -o pipefail

--- a/OCP-4.X/roles/install/templates/registry_auth.j2
+++ b/OCP-4.X/roles/install/templates/registry_auth.j2
@@ -1,0 +1,10 @@
+{
+	"auths": {
+		"quay.io": {
+			"auth": "{{ OPENSHIFT_INSTALL_QUAY_REGISTRY_TOKEN }}"
+		},
+                "{{ OPENSHIFT_INSTALL_IMAGE_REGISTRY }}": {
+			"auth": "{{ OPENSHIFT_INSTALL_REGISTRY_TOKEN }}"
+		}
+	}
+}


### PR DESCRIPTION
This commit adds support to the automation to extract the openshift-install
binary from the payload instead of the github release. This way the OCP
installs are more stable.