### PR TITLE
Add support for 4.x AWS Clusters created by Flexy, new post-install inventory variable KUBECONFIG_AUTH_DIR_PATH

### DIFF
--- a/OCP-4.X/inventory.example
+++ b/OCP-4.X/inventory.example
@@ -81,6 +81,9 @@ RHCOS_PBENCH_NODE_VOLUME_TYPE=gp2
 PROMETHEUS_RETENTION_PERIOD=15d
 PROMETHEUS_STORAGE_SIZE=20Gi
 ALERTMANAGER_STORAGE_SIZE=10Gi
+## To specify an alternate auth dir containing kubeconfig, e.g. from AWS cluster installed by Flexy,
+## use only when NOT using the default auth dir located in "${GOPATH}/src/github.com/openshift/installer" 
+KUBECONFIG_AUTH_DIR_PATH= 
 
 # openshift tooling
 OPENSHIFT_TOOLING=True

--- a/OCP-4.X/roles/controller-kickstart/tasks/main.yml
+++ b/OCP-4.X/roles/controller-kickstart/tasks/main.yml
@@ -2,7 +2,17 @@
 - name: set workdir
   set_fact:
     workdir: "{{ GOPATH }}/src/github.com/openshift/installer"
+  when:
+    - KUBECONFIG_AUTH_DIR_PATH is undefined
 
+# Needed when using an AWS cluster installed by Flexy
+- name: set workdir when KUBECONFIG_AUTH_DIR_PATH is defined
+  set_fact:
+    workdir: "{{ KUBECONFIG_AUTH_DIR_PATH }}"
+  when: 
+    - KUBECONFIG_AUTH_DIR_PATH is defined
+    - KUBECONFIG_AUTH_DIR_PATH != ""
+    
 - name: ensure that .kube dir exists on controller
   file:
     path: "{{ item }}"
@@ -64,3 +74,4 @@
   add_host: name={{ item }} groups=nodes
   with_items:
     - "{{ ocp_nodes.stdout_lines }}"
+


### PR DESCRIPTION
In order to setup the containerized tooling on an OCP 4.x cluster installed by Flexy, we need to specify the location of the auth dir containing the kubeconfig for that cluster on the jump host.  This is needed in OCP-4.X role controller-kickstart task set_fact workdir:

- Created a new inventory post-install variable "KUBECONFIG_AUTH_DIR_PATH" to specify the path of the auth dir containing the cluster kubeconfig file.

- Updated  OCP-4.X role task controller-kickstart to set workdir to value stored in KUBECONFIG_AUTH_DIR_PATH only when it is defined.  Otherwise the default workdir "{{ GOPATH }}/src/github.com/openshift/installer" value is set.
