### PR TITLE
Clean up old installer in all cases

### DIFF
--- a/OCP-4.X/roles/install/tasks/main.yml
+++ b/OCP-4.X/roles/install/tasks/main.yml
@@ -39,12 +39,12 @@
   set_fact:
     workdir: "{{ GOPATH }}/src/github.com/openshift/installer"
 
-- block:
-    - name: cleanup installer code if it exists
-      file:
-        path: "{{ workdir }}"
-        state: absent
+- name: cleanup installer code if it exists
+  file:
+    path: "{{ workdir }}"
+    state: absent
 
+- block:
     - name: get the installer bits
       git:
         repo: 'https://github.com/openshift/installer.git'


### PR DESCRIPTION
Without cleaning up any old installer code first, we always run the risk of using an old or newer installer instead of the intended installer