### PR TITLE
Added to the aws-cloud-credentials credentialsSecret to pbench and infra node machinesets

### DIFF
--- a/OCP-4.X/roles/post-install/templates/infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/infra-node-machineset.yml.j2
@@ -39,6 +39,8 @@ items:
                 iops: {{RHCOS_INFRA_NODE_VOLUME_IOPS}}
                 volumeSize: {{RHCOS_INFRA_NODE_VOLUME_SIZE}}
                 volumeType: {{RHCOS_INFRA_NODE_VOLUME_TYPE}}
+            credentialsSecret:
+              name: aws-cloud-credentials
             deviceIndex: 0
             iamInstanceProfile:
               id: {{rhcos_cluster_name.stdout}}-worker-profile
@@ -108,6 +110,8 @@ items:
                 iops: {{RHCOS_INFRA_NODE_VOLUME_IOPS}}
                 volumeSize: {{RHCOS_INFRA_NODE_VOLUME_SIZE}}
                 volumeType: {{RHCOS_INFRA_NODE_VOLUME_TYPE}}
+            credentialsSecret:
+              name: aws-cloud-credentials
             deviceIndex: 0
             iamInstanceProfile:
               id: {{rhcos_cluster_name.stdout}}-worker-profile
@@ -177,6 +181,8 @@ items:
                 iops: {{RHCOS_INFRA_NODE_VOLUME_IOPS}}
                 volumeSize: {{RHCOS_INFRA_NODE_VOLUME_SIZE}}
                 volumeType: {{RHCOS_INFRA_NODE_VOLUME_TYPE}}
+            credentialsSecret:
+              name: aws-cloud-credentials
             deviceIndex: 0
             iamInstanceProfile:
               id: {{rhcos_cluster_name.stdout}}-worker-profile

--- a/OCP-4.X/roles/post-install/templates/pbench-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/pbench-node-machineset.yml.j2
@@ -39,6 +39,8 @@ items:
                 iops: {{RHCOS_PBENCH_NODE_VOLUME_IOPS}}
                 volumeSize: {{RHCOS_PBENCH_NODE_VOLUME_SIZE}}
                 volumeType: {{RHCOS_PBENCH_NODE_VOLUME_TYPE}}
+            credentialsSecret:
+              name: aws-cloud-credentials
             deviceIndex: 0
             iamInstanceProfile:
               id: {{rhcos_cluster_name.stdout}}-worker-profile


### PR DESCRIPTION
On latest OCP 4.1 builds (noticed on 4.1.0-0.nightly-2019-05-16-223922), machineset templates require in the following credentialsSecret in providerSpec:

            credentialsSecret:
              name: aws-cloud-credentials
